### PR TITLE
Take a ref to an existing string/sequence in {De,En}coder.{feed,flush}

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -5,7 +5,7 @@ CXX ?= g++
 CXXFLAGS ?=
 AR ?= ar
 RUSTC ?= rustc
-RUSTFLAGS ?= -O
+RUSTFLAGS ?= -O -A default-methods
 
 RUST_SRC=$(shell find $(VPATH)/src/. -type f -name '*.rs')
 

--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -24,12 +24,11 @@ pub struct ASCIIEncoder;
 impl Encoder for ASCIIEncoder {
     pub fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str) -> (~[u8],Option<EncoderError<'r>>) {
-        let mut ret = ~[];
+    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             if ch <= '\u007f' {
-                ret.push(ch as u8);
+                output.push(ch as u8);
             } else {
                 err = Some(CodecError {
                     remaining: input.slice_from(j),
@@ -39,11 +38,11 @@ impl Encoder for ASCIIEncoder {
                 break;
             }
         }
-        (ret, err)
+        err
     }
 
-    pub fn flush(~self) -> (~[u8],Option<EncoderError<'static>>) {
-        (~[], None)
+    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+        None
     }
 }
 
@@ -53,27 +52,26 @@ pub struct ASCIIDecoder;
 impl Decoder for ASCIIDecoder {
     pub fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8]) -> (~str,Option<DecoderError<'r>>) {
-        let mut ret = ~"";
+    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         let mut i = 0;
         let len = input.len();
         while i < len {
             if input[i] <= 0x7f {
-                ret.push_char(input[i] as char);
+                output.push_char(input[i] as char);
             } else {
-                return (ret, Some(CodecError {
+                return Some(CodecError {
                     remaining: input.slice(i+1, len),
                     problem: ~[input[i]],
                     cause: ~"invalid sequence",
-                }));
+                });
             }
             i += 1;
         }
-        (ret, None)
+        None
     }
 
-    pub fn flush(~self) -> (~str,Option<DecoderError<'static>>) {
-        (~"", None)
+    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+        None
     }
 }
 
@@ -98,21 +96,21 @@ mod tests {
     #[test]
     fn test_encoder() {
         let mut e = ASCIIEncoding.encoder();
-        assert_result!(e.feed("A"), (~[0x41], None));
-        assert_result!(e.feed("BC"), (~[0x42, 0x43], None));
-        assert_result!(e.feed(""), (~[], None));
-        assert_result!(e.feed("\xa0"), (~[], Some(("", ~"\xa0"))));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("A"), (~[0x41], None));
+        assert_result!(e.test_feed("BC"), (~[0x42, 0x43], None));
+        assert_result!(e.test_feed(""), (~[], None));
+        assert_result!(e.test_feed("\xa0"), (~[], Some(("", ~"\xa0"))));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_decoder() {
         let mut d = ASCIIEncoding.decoder();
-        assert_result!(d.feed(&[0x41]), (~"A", None));
-        assert_result!(d.feed(&[0x42, 0x43]), (~"BC", None));
-        assert_result!(d.feed(&[]), (~"", None));
-        assert_result!(d.feed(&[0xa0]), (~"", Some((&[], ~[0xa0]))));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_feed(&[0x41]), (~"A", None));
+        assert_result!(d.test_feed(&[0x42, 0x43]), (~"BC", None));
+        assert_result!(d.test_feed(&[]), (~"", None));
+        assert_result!(d.test_feed(&[0xa0]), (~"", Some((&[], ~[0xa0]))));
+        assert_result!(d.test_flush(), (~"", None));
     }
 }
 

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -23,21 +23,22 @@ pub struct ErrorEncoder;
 impl Encoder for ErrorEncoder {
     pub fn encoding(&self) -> ~Encoding { ~ErrorEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str) -> (~[u8],Option<EncoderError<'r>>) {
+    pub fn feed<'r>(&mut self, input: &'r str, _output: &mut ~[u8])
+                      -> Option<EncoderError<'r>> {
         if input.len() > 0 {
             let str::CharRange {ch, next} = input.char_range_at(0);
-            (~[], Some(CodecError {
+            Some(CodecError {
                 remaining: input.slice_from(next),
                 problem: str::from_char(ch),
                 cause: ~"unrepresentable character",
-            }))
+            })
         } else {
-            (~[], None)
+            None
         }
     }
 
-    pub fn flush(~self) -> (~[u8],Option<EncoderError<'static>>) {
-        (~[], None)
+    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+        None
     }
 }
 
@@ -47,20 +48,21 @@ pub struct ErrorDecoder;
 impl Decoder for ErrorDecoder {
     pub fn encoding(&self) -> ~Encoding { ~ErrorEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8]) -> (~str,Option<DecoderError<'r>>) {
+    pub fn feed<'r>(&mut self, input: &'r [u8], _output: &mut ~str)
+                      -> Option<DecoderError<'r>> {
         if input.len() > 0 {
-            (~"", Some(CodecError {
+            Some(CodecError {
                 remaining: input.slice(1, input.len()),
                 problem: ~[input[0]],
                 cause: ~"invalid sequence",
-            }))
+            })
         } else {
-            (~"", None)
+            None
         }
     }
 
-    pub fn flush(~self) -> (~str,Option<DecoderError<'static>>) {
-        (~"", None)
+    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+        None
     }
 }
 
@@ -85,21 +87,21 @@ mod tests {
     #[test]
     fn test_encoder() {
         let mut e = ErrorEncoding.encoder();
-        assert_result!(e.feed("A"), (~[], Some(("", ~"A"))));
-        assert_result!(e.feed("BC"), (~[], Some(("C", ~"B"))));
-        assert_result!(e.feed(""), (~[], None));
-        assert_result!(e.feed("\xa0"), (~[], Some(("", ~"\xa0"))));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("A"), (~[], Some(("", ~"A"))));
+        assert_result!(e.test_feed("BC"), (~[], Some(("C", ~"B"))));
+        assert_result!(e.test_feed(""), (~[], None));
+        assert_result!(e.test_feed("\xa0"), (~[], Some(("", ~"\xa0"))));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_decoder() {
         let mut d = ErrorEncoding.decoder();
-        assert_result!(d.feed(&[0x41]), (~"", Some((&[], ~[0x41]))));
-        assert_result!(d.feed(&[0x42, 0x43]), (~"", Some((&[0x43], ~[0x42]))));
-        assert_result!(d.feed(&[]), (~"", None));
-        assert_result!(d.feed(&[0xa0]), (~"", Some((&[], ~[0xa0]))));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_feed(&[0x41]), (~"", Some((&[], ~[0x41]))));
+        assert_result!(d.test_feed(&[0x42, 0x43]), (~"", Some((&[0x43], ~[0x42]))));
+        assert_result!(d.test_feed(&[]), (~"", None));
+        assert_result!(d.test_feed(&[0xa0]), (~"", Some((&[], ~[0xa0]))));
+        assert_result!(d.test_flush(), (~"", None));
     }
 }
 

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -26,17 +26,16 @@ pub struct EUCJPEncoder;
 impl Encoder for EUCJPEncoder {
     pub fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str) -> (~[u8],Option<EncoderError<'r>>) {
-        let mut ret = ~[];
+    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             match ch {
-                '\u0000'..'\u007f' => { ret.push(ch as u8); }
-                '\u00a5' => { ret.push(0x5c); }
-                '\u203e' => { ret.push(0x7e); }
+                '\u0000'..'\u007f' => { output.push(ch as u8); }
+                '\u00a5' => { output.push(0x5c); }
+                '\u203e' => { output.push(0x7e); }
                 '\uff61'..'\uff9f' => {
-                    ret.push(0x8e);
-                    ret.push((ch as uint - 0xff61 + 0xa1) as u8);
+                    output.push(0x8e);
+                    output.push((ch as uint - 0xff61 + 0xa1) as u8);
                 }
                 _ => {
                     let ptr = index0208::backward(ch as u32);
@@ -50,17 +49,17 @@ impl Encoder for EUCJPEncoder {
                     } else {
                         let lead = ptr / 94 + 0xa1;
                         let trail = ptr % 94 + 0xa1;
-                        ret.push(lead as u8);
-                        ret.push(trail as u8);
+                        output.push(lead as u8);
+                        output.push(trail as u8);
                     }
                 }
             }
         }
-        (ret, err)
+        err
     }
 
-    pub fn flush(~self) -> (~[u8],Option<EncoderError<'static>>) {
-        (~[], None)
+    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+        None
     }
 }
 
@@ -73,8 +72,7 @@ pub struct EUCJPDecoder {
 impl Decoder for EUCJPDecoder {
     pub fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8]) -> (~str,Option<DecoderError<'r>>) {
-        let mut ret = ~"";
+    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         let mut i = 0;
         let len = input.len();
 
@@ -83,7 +81,7 @@ impl Decoder for EUCJPDecoder {
             let trail = input[i] as uint;
             match (lead, trail) {
                 (0x8e, 0xa1..0xdf) => {
-                    ret.push_char((0xff61 + trail - 0xa1) as char);
+                    output.push_char((0xff61 + trail - 0xa1) as char);
                 }
                 (0x8f, _) => {
                     self.first = 0;
@@ -99,14 +97,14 @@ impl Decoder for EUCJPDecoder {
                         0xffff => {
                             self.first = 0;
                             let inclusive = (trail >= 0x80);
-                            return (ret, Some(CodecError {
+                            return Some(CodecError {
                                 remaining: input.slice(if inclusive {i+1} else {i}, len),
                                 problem: if inclusive {~[lead as u8, trail as u8]}
                                                  else {~[lead as u8]},
                                 cause: ~"invalid sequence",
-                            }));
+                            });
                         }
-                        ch => { ret.push_char(ch as char); }
+                        ch => { output.push_char(ch as char); }
                     }
                 }
             }
@@ -124,14 +122,14 @@ impl Decoder for EUCJPDecoder {
                 0xffff => {
                     self.second = 0;
                     let inclusive = (byte >= 0x80);
-                    return (ret, Some(CodecError {
+                    return Some(CodecError {
                         remaining: input.slice(if inclusive {i+1} else {i}, len),
                         problem: if inclusive {~[0x8f, trail as u8, byte as u8]}
                                          else {~[0x8f, trail as u8]},
                         cause: ~"invalid sequence",
-                    }));
+                    });
                 }
-                ch => { ret.push_char(ch as char); }
+                ch => { output.push_char(ch as char); }
             }
             i += 1;
         }
@@ -140,7 +138,7 @@ impl Decoder for EUCJPDecoder {
         self.second = 0;
         while i < len {
             if input[i] < 0x80 {
-                ret.push_char(input[i] as char);
+                output.push_char(input[i] as char);
             } else {
                 i += 1;
                 if i >= len { // we wait for a trail byte even if the lead is obviously invalid
@@ -152,7 +150,7 @@ impl Decoder for EUCJPDecoder {
                 let trail = input[i] as uint;
                 match (lead, trail) {
                     (0x8e, 0xa1..0xdf) => {
-                        ret.push_char((0xff61 + trail - 0xa1) as char);
+                        output.push_char((0xff61 + trail - 0xa1) as char);
                     }
                     (0x8f, _) => { // JIS X 0212 three-byte sequence
                         i += 1;
@@ -168,14 +166,14 @@ impl Decoder for EUCJPDecoder {
                         match index0212::forward(index as u16) {
                             0xffff => {
                                 let inclusive = (byte >= 0x80);
-                                return (ret, Some(CodecError {
+                                return Some(CodecError {
                                     remaining: input.slice(if inclusive {i+1} else {i}, len),
                                     problem: if inclusive {~[0x8f, trail as u8, byte as u8]}
                                                      else {~[0x8f, trail as u8]},
                                     cause: ~"invalid sequence",
-                                }));
+                                });
                             }
-                            ch => { ret.push_char(ch as char); }
+                            ch => { output.push_char(ch as char); }
                         }
                     }
                     (_, _) => {
@@ -186,34 +184,34 @@ impl Decoder for EUCJPDecoder {
                         match index0208::forward(index as u16) {
                             0xffff => {
                                 let inclusive = (trail >= 0x80);
-                                return (ret, Some(CodecError {
+                                return Some(CodecError {
                                     remaining: input.slice(if inclusive {i+1} else {i}, len),
                                     problem: if inclusive {~[lead as u8, trail as u8]}
                                                      else {~[lead as u8]},
                                     cause: ~"invalid sequence",
-                                }));
+                                });
                             }
-                            ch => { ret.push_char(ch as char); }
+                            ch => { output.push_char(ch as char); }
                         }
                     }
                 }
             }
             i += 1;
         }
-        (ret, None)
+        None
     }
 
-    pub fn flush(~self) -> (~str,Option<DecoderError<'static>>) {
+    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         if self.second != 0 {
-            (~"", Some(CodecError { remaining: &[],
-                                    problem: ~[0x8f, self.second],
-                                    cause: ~"incomplete sequence" }))
+            Some(CodecError { remaining: &[],
+                              problem: ~[0x8f, self.second],
+                              cause: ~"incomplete sequence" })
         } else if self.first != 0 {
-            (~"", Some(CodecError { remaining: &[],
-                                    problem: ~[self.first],
-                                    cause: ~"incomplete sequence" }))
+            Some(CodecError { remaining: &[],
+                              problem: ~[self.first],
+                              cause: ~"incomplete sequence" })
         } else {
-            (~"", None)
+            None
         }
     }
 }
@@ -239,42 +237,42 @@ mod eucjp_tests {
     #[test]
     fn test_encoder_valid() {
         let mut e = EUCJPEncoding.encoder();
-        assert_result!(e.feed("A"), (~[0x41], None));
-        assert_result!(e.feed("BC"), (~[0x42, 0x43], None));
-        assert_result!(e.feed(""), (~[], None));
-        assert_result!(e.feed("\u00a5"), (~[0x5c], None));
-        assert_result!(e.feed("\u203e"), (~[0x7e], None));
-        assert_result!(e.feed("\u306b\u307b\u3093"), (~[0xa4, 0xcb, 0xa4, 0xdb, 0xa4, 0xf3], None));
-        assert_result!(e.feed("\uff86\uff8e\uff9d"), (~[0x8e, 0xc6, 0x8e, 0xce, 0x8e, 0xdd], None));
-        assert_result!(e.feed("\u65e5\u672c"), (~[0xc6, 0xfc, 0xcb, 0xdc], None));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("A"), (~[0x41], None));
+        assert_result!(e.test_feed("BC"), (~[0x42, 0x43], None));
+        assert_result!(e.test_feed(""), (~[], None));
+        assert_result!(e.test_feed("\u00a5"), (~[0x5c], None));
+        assert_result!(e.test_feed("\u203e"), (~[0x7e], None));
+        assert_result!(e.test_feed("\u306b\u307b\u3093"), (~[0xa4, 0xcb, 0xa4, 0xdb, 0xa4, 0xf3], None));
+        assert_result!(e.test_feed("\uff86\uff8e\uff9d"), (~[0x8e, 0xc6, 0x8e, 0xce, 0x8e, 0xdd], None));
+        assert_result!(e.test_feed("\u65e5\u672c"), (~[0xc6, 0xfc, 0xcb, 0xdc], None));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_encoder_invalid() {
         let mut e = EUCJPEncoding.encoder();
-        assert_result!(e.feed("\uffff"), (~[], Some(("", ~"\uffff"))));
-        assert_result!(e.feed("?\uffff!"), (~[0x3f], Some(("!", ~"\uffff"))));
+        assert_result!(e.test_feed("\uffff"), (~[], Some(("", ~"\uffff"))));
+        assert_result!(e.test_feed("?\uffff!"), (~[0x3f], Some(("!", ~"\uffff"))));
         // JIS X 0212 is not supported in the encoder
-        assert_result!(e.feed("\u736c\u8c78"), (~[], Some(("\u8c78", ~"\u736c"))));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("\u736c\u8c78"), (~[], Some(("\u8c78", ~"\u736c"))));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_decoder_valid() {
         let mut d = EUCJPEncoding.decoder();
-        assert_result!(d.feed(&[0x41]), (~"A", None));
-        assert_result!(d.feed(&[0x42, 0x43]), (~"BC", None));
-        assert_result!(d.feed(&[]), (~"", None));
-        assert_result!(d.feed(&[0x5c]), (~"\\", None));
-        assert_result!(d.feed(&[0x7e]), (~"~", None));
-        assert_result!(d.feed(&[0xa4, 0xcb, 0xa4, 0xdb, 0xa4, 0xf3]),
+        assert_result!(d.test_feed(&[0x41]), (~"A", None));
+        assert_result!(d.test_feed(&[0x42, 0x43]), (~"BC", None));
+        assert_result!(d.test_feed(&[]), (~"", None));
+        assert_result!(d.test_feed(&[0x5c]), (~"\\", None));
+        assert_result!(d.test_feed(&[0x7e]), (~"~", None));
+        assert_result!(d.test_feed(&[0xa4, 0xcb, 0xa4, 0xdb, 0xa4, 0xf3]),
                        (~"\u306b\u307b\u3093", None));
-        assert_result!(d.feed(&[0x8e, 0xc6, 0x8e, 0xce, 0x8e, 0xdd]),
+        assert_result!(d.test_feed(&[0x8e, 0xc6, 0x8e, 0xce, 0x8e, 0xdd]),
                        (~"\uff86\uff8e\uff9d", None));
-        assert_result!(d.feed(&[0xc6, 0xfc, 0xcb, 0xdc]), (~"\u65e5\u672c", None));
-        assert_result!(d.feed(&[0x8f, 0xcb, 0xc6, 0xec, 0xb8]), (~"\u736c\u8c78", None));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_feed(&[0xc6, 0xfc, 0xcb, 0xdc]), (~"\u65e5\u672c", None));
+        assert_result!(d.test_feed(&[0x8f, 0xcb, 0xc6, 0xec, 0xb8]), (~"\u736c\u8c78", None));
+        assert_result!(d.test_flush(), (~"", None));
     }
 
     // TODO more tests
@@ -296,15 +294,14 @@ pub struct ShiftJISEncoder;
 impl Encoder for ShiftJISEncoder {
     pub fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str) -> (~[u8],Option<EncoderError<'r>>) {
-        let mut ret = ~[];
+    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             match ch {
-                '\u0000'..'\u0080' => { ret.push(ch as u8); }
-                '\u00a5' => { ret.push(0x5c); }
-                '\u203e' => { ret.push(0x7e); }
-                '\uff61'..'\uff9f' => { ret.push((ch as uint - 0xff61 + 0xa1) as u8); }
+                '\u0000'..'\u0080' => { output.push(ch as u8); }
+                '\u00a5' => { output.push(0x5c); }
+                '\u203e' => { output.push(0x7e); }
+                '\uff61'..'\uff9f' => { output.push((ch as uint - 0xff61 + 0xa1) as u8); }
                 _ => {
                     let ptr = index0208::backward(ch as u32);
                     if ptr == 0xffff {
@@ -319,17 +316,17 @@ impl Encoder for ShiftJISEncoder {
                         let leadoffset = if lead < 0x1f {0x81} else {0xc1};
                         let trail = ptr % 188;
                         let trailoffset = if trail < 0x3f {0x40} else {0x41};
-                        ret.push((lead + leadoffset) as u8);
-                        ret.push((trail + trailoffset) as u8);
+                        output.push((lead + leadoffset) as u8);
+                        output.push((trail + trailoffset) as u8);
                     }
                 }
             }
         }
-        (ret, err)
+        err
     }
 
-    pub fn flush(~self) -> (~[u8],Option<EncoderError<'static>>) {
-        (~[], None)
+    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+        None
     }
 }
 
@@ -341,8 +338,7 @@ pub struct ShiftJISDecoder {
 impl Decoder for ShiftJISDecoder {
     pub fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8]) -> (~str,Option<DecoderError<'r>>) {
-        let mut ret = ~"";
+    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         let mut i = 0;
         let len = input.len();
 
@@ -362,13 +358,13 @@ impl Decoder for ShiftJISDecoder {
                 0xffff => {
                     self.lead = 0;
                     let inclusive = (trail >= 0x80);
-                    return (ret, Some(CodecError {
+                    return Some(CodecError {
                         remaining: input.slice(if inclusive {i+1} else {i}, len),
                         problem: if inclusive {~[lead as u8, trail as u8]} else {~[lead as u8]},
                         cause: ~"invalid sequence",
-                    }));
+                    });
                 }
-                ch => { ret.push_char(ch as char); }
+                ch => { output.push_char(ch as char); }
             }
             i += 1;
         }
@@ -377,10 +373,10 @@ impl Decoder for ShiftJISDecoder {
         while i < len {
             match input[i] {
                 0x00..0x7f => {
-                    ret.push_char(input[i] as char);
+                    output.push_char(input[i] as char);
                 }
                 0xa1..0xdf => {
-                    ret.push_char((0xff61 + (input[i] as uint) - 0xa1) as char);
+                    output.push_char((0xff61 + (input[i] as uint) - 0xa1) as char);
                 }
                 _ => {
                     i += 1;
@@ -403,29 +399,29 @@ impl Decoder for ShiftJISDecoder {
                     match index0208::forward(index as u16) {
                         0xffff => {
                             let inclusive = (trail >= 0x80);
-                            return (ret, Some(CodecError {
+                            return Some(CodecError {
                                 remaining: input.slice(if inclusive {i+1} else {i}, len),
                                 problem: if inclusive {~[lead as u8, trail as u8]}
                                                  else {~[lead as u8]},
                                 cause: ~"invalid sequence",
-                            }));
+                            });
                         }
-                        ch => { ret.push_char(ch as char); }
+                        ch => { output.push_char(ch as char); }
                     }
                 }
             }
             i += 1;
         }
-        (ret, None)
+        None
     }
 
-    pub fn flush(~self) -> (~str,Option<DecoderError<'static>>) {
+    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         if self.lead != 0 {
-            (~"", Some(CodecError { remaining: &[],
-                                    problem: ~[self.lead],
-                                    cause: ~"incomplete sequence" }))
+            Some(CodecError { remaining: &[],
+                              problem: ~[self.lead],
+                              cause: ~"incomplete sequence" })
         } else {
-            (~"", None)
+            None
         }
     }
 }
@@ -451,39 +447,39 @@ mod shiftjis_tests {
     #[test]
     fn test_encoder_valid() {
         let mut e = ShiftJISEncoding.encoder();
-        assert_result!(e.feed("A"), (~[0x41], None));
-        assert_result!(e.feed("BC"), (~[0x42, 0x43], None));
-        assert_result!(e.feed(""), (~[], None));
-        assert_result!(e.feed("\u00a5"), (~[0x5c], None));
-        assert_result!(e.feed("\u203e"), (~[0x7e], None));
-        assert_result!(e.feed("\u306b\u307b\u3093"), (~[0x82, 0xc9, 0x82, 0xd9, 0x82, 0xf1], None));
-        assert_result!(e.feed("\uff86\uff8e\uff9d"), (~[0xc6, 0xce, 0xdd], None));
-        assert_result!(e.feed("\u65e5\u672c"), (~[0x93, 0xfa, 0x96, 0x7b], None));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("A"), (~[0x41], None));
+        assert_result!(e.test_feed("BC"), (~[0x42, 0x43], None));
+        assert_result!(e.test_feed(""), (~[], None));
+        assert_result!(e.test_feed("\u00a5"), (~[0x5c], None));
+        assert_result!(e.test_feed("\u203e"), (~[0x7e], None));
+        assert_result!(e.test_feed("\u306b\u307b\u3093"), (~[0x82, 0xc9, 0x82, 0xd9, 0x82, 0xf1], None));
+        assert_result!(e.test_feed("\uff86\uff8e\uff9d"), (~[0xc6, 0xce, 0xdd], None));
+        assert_result!(e.test_feed("\u65e5\u672c"), (~[0x93, 0xfa, 0x96, 0x7b], None));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_encoder_invalid() {
         let mut e = ShiftJISEncoding.encoder();
-        assert_result!(e.feed("\uffff"), (~[], Some(("", ~"\uffff"))));
-        assert_result!(e.feed("?\uffff!"), (~[0x3f], Some(("!", ~"\uffff"))));
-        assert_result!(e.feed("\u736c\u8c78"), (~[], Some(("\u8c78", ~"\u736c"))));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("\uffff"), (~[], Some(("", ~"\uffff"))));
+        assert_result!(e.test_feed("?\uffff!"), (~[0x3f], Some(("!", ~"\uffff"))));
+        assert_result!(e.test_feed("\u736c\u8c78"), (~[], Some(("\u8c78", ~"\u736c"))));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_decoder_valid() {
         let mut d = ShiftJISEncoding.decoder();
-        assert_result!(d.feed(&[0x41]), (~"A", None));
-        assert_result!(d.feed(&[0x42, 0x43]), (~"BC", None));
-        assert_result!(d.feed(&[]), (~"", None));
-        assert_result!(d.feed(&[0x5c]), (~"\\", None));
-        assert_result!(d.feed(&[0x7e]), (~"~", None));
-        assert_result!(d.feed(&[0x82, 0xc9, 0x82, 0xd9, 0x82, 0xf1]),
+        assert_result!(d.test_feed(&[0x41]), (~"A", None));
+        assert_result!(d.test_feed(&[0x42, 0x43]), (~"BC", None));
+        assert_result!(d.test_feed(&[]), (~"", None));
+        assert_result!(d.test_feed(&[0x5c]), (~"\\", None));
+        assert_result!(d.test_feed(&[0x7e]), (~"~", None));
+        assert_result!(d.test_feed(&[0x82, 0xc9, 0x82, 0xd9, 0x82, 0xf1]),
                        (~"\u306b\u307b\u3093", None));
-        assert_result!(d.feed(&[0xc6, 0xce, 0xdd]), (~"\uff86\uff8e\uff9d", None));
-        assert_result!(d.feed(&[0x93, 0xfa, 0x96, 0x7b]), (~"\u65e5\u672c", None));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_feed(&[0xc6, 0xce, 0xdd]), (~"\uff86\uff8e\uff9d", None));
+        assert_result!(d.test_feed(&[0x93, 0xfa, 0x96, 0x7b]), (~"\u65e5\u672c", None));
+        assert_result!(d.test_flush(), (~"", None));
     }
 
     // TODO more tests

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -25,12 +25,11 @@ pub struct Windows949Encoder;
 impl Encoder for Windows949Encoder {
     pub fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str) -> (~[u8],Option<EncoderError<'r>>) {
-        let mut ret = ~[];
+    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             if ch <= '\u007f' {
-                ret.push(ch as u8);
+                output.push(ch as u8);
             } else {
                 let ptr = index::backward(ch as u32);
                 if ptr == 0xffff {
@@ -44,22 +43,22 @@ impl Encoder for Windows949Encoder {
                     let lead = ptr / (26 + 26 + 126) + 0x81;
                     let trail = ptr % (26 + 26 + 126);
                     let offset = if trail < 26 {0x41} else if trail < 26 + 26 {0x47} else {0x4d};
-                    ret.push(lead as u8);
-                    ret.push((trail + offset) as u8);
+                    output.push(lead as u8);
+                    output.push((trail + offset) as u8);
                 } else {
                     let ptr = ptr - (26 + 26 + 126) * (0xc7 - 0x81);
                     let lead = ptr / 94 + 0xc7;
                     let trail = ptr % 94 + 0xa1;
-                    ret.push(lead as u8);
-                    ret.push(trail as u8);
+                    output.push(lead as u8);
+                    output.push(trail as u8);
                 }
             }
         }
-        (ret, err)
+        err
     }
 
-    pub fn flush(~self) -> (~[u8],Option<EncoderError<'static>>) {
-        (~[], None)
+    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+        None
     }
 }
 
@@ -71,8 +70,7 @@ pub struct Windows949Decoder {
 impl Decoder for Windows949Decoder {
     pub fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8]) -> (~str,Option<DecoderError<'r>>) {
-        let mut ret = ~"";
+    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         let mut i = 0;
         let len = input.len();
 
@@ -94,13 +92,13 @@ impl Decoder for Windows949Decoder {
                 0xffff => {
                     self.lead = 0;
                     let inclusive = (trail >= 0x80); // true if the trail byte is in the problem
-                    return (ret, Some(CodecError {
+                    return Some(CodecError {
                         remaining: input.slice(if inclusive {i+1} else {i}, len),
                         problem: if inclusive {~[lead as u8, trail as u8]} else {~[lead as u8]},
                         cause: ~"invalid sequence",
-                    }));
+                    });
                 }
-                ch => { ret.push_char(ch as char); }
+                ch => { output.push_char(ch as char); }
             }
             i += 1;
         }
@@ -108,7 +106,7 @@ impl Decoder for Windows949Decoder {
         self.lead = 0;
         while i < len {
             if input[i] < 0x80 {
-                ret.push_char(input[i] as char);
+                output.push_char(input[i] as char);
             } else {
                 i += 1;
                 if i >= len { // we wait for a trail byte even if the lead is obviously invalid
@@ -132,28 +130,28 @@ impl Decoder for Windows949Decoder {
                 match index::forward(index as u16) {
                     0xffff => {
                         let inclusive = (trail >= 0x80); // true if the trail byte is in the problem
-                        return (ret, Some(CodecError {
+                        return Some(CodecError {
                             remaining: input.slice(if inclusive {i+1} else {i}, len),
                             problem: if inclusive {~[lead as u8, trail as u8]}
                                              else {~[lead as u8]},
                             cause: ~"invalid sequence",
-                        }));
+                        });
                     }
-                    ch => { ret.push_char(ch as char); }
+                    ch => { output.push_char(ch as char); }
                 }
             }
             i += 1;
         }
-        (ret, None)
+        None
     }
 
-    pub fn flush(~self) -> (~str,Option<DecoderError<'static>>) {
+    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         if self.lead != 0 {
-            (~"", Some(CodecError { remaining: &[],
-                                    problem: ~[self.lead],
-                                    cause: ~"incomplete sequence" }))
+            Some(CodecError { remaining: &[],
+                              problem: ~[self.lead],
+                              cause: ~"incomplete sequence" })
         } else {
-            (~"", None)
+            None
         }
     }
 }
@@ -180,54 +178,54 @@ mod euckr_tests {
     #[test]
     fn test_encoder_valid() {
         let mut e = Windows949Encoding.encoder();
-        assert_result!(e.feed("A"), (~[0x41], None));
-        assert_result!(e.feed("BC"), (~[0x42, 0x43], None));
-        assert_result!(e.feed(""), (~[], None));
-        assert_result!(e.feed("\uac00"), (~[0xb0, 0xa1], None));
-        assert_result!(e.feed("\ub098\ub2e4"), (~[0xb3, 0xaa, 0xb4, 0xd9], None));
-        assert_result!(e.feed("\ubdc1\u314b\ud7a3"), (~[0x94, 0xee, 0xa4, 0xbb, 0xc6, 0x52], None));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("A"), (~[0x41], None));
+        assert_result!(e.test_feed("BC"), (~[0x42, 0x43], None));
+        assert_result!(e.test_feed(""), (~[], None));
+        assert_result!(e.test_feed("\uac00"), (~[0xb0, 0xa1], None));
+        assert_result!(e.test_feed("\ub098\ub2e4"), (~[0xb3, 0xaa, 0xb4, 0xd9], None));
+        assert_result!(e.test_feed("\ubdc1\u314b\ud7a3"), (~[0x94, 0xee, 0xa4, 0xbb, 0xc6, 0x52], None));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_encoder_invalid() {
         let mut e = Windows949Encoding.encoder();
-        assert_result!(e.feed("\uffff"), (~[], Some(("", ~"\uffff"))));
-        assert_result!(e.feed("?\uffff!"), (~[0x3f], Some(("!", ~"\uffff"))));
-        assert_result!(e.flush(), (~[], None));
+        assert_result!(e.test_feed("\uffff"), (~[], Some(("", ~"\uffff"))));
+        assert_result!(e.test_feed("?\uffff!"), (~[0x3f], Some(("!", ~"\uffff"))));
+        assert_result!(e.test_flush(), (~[], None));
     }
 
     #[test]
     fn test_decoder_valid() {
         let mut d = Windows949Encoding.decoder();
-        assert_result!(d.feed(&[0x41]), (~"A", None));
-        assert_result!(d.feed(&[0x42, 0x43]), (~"BC", None));
-        assert_result!(d.feed(&[]), (~"", None));
-        assert_result!(d.feed(&[0xb0, 0xa1]), (~"\uac00", None));
-        assert_result!(d.feed(&[0xb3, 0xaa, 0xb4, 0xd9]), (~"\ub098\ub2e4", None));
-        assert_result!(d.feed(&[0x94, 0xee, 0xa4, 0xbb, 0xc6, 0x52]),
+        assert_result!(d.test_feed(&[0x41]), (~"A", None));
+        assert_result!(d.test_feed(&[0x42, 0x43]), (~"BC", None));
+        assert_result!(d.test_feed(&[]), (~"", None));
+        assert_result!(d.test_feed(&[0xb0, 0xa1]), (~"\uac00", None));
+        assert_result!(d.test_feed(&[0xb3, 0xaa, 0xb4, 0xd9]), (~"\ub098\ub2e4", None));
+        assert_result!(d.test_feed(&[0x94, 0xee, 0xa4, 0xbb, 0xc6, 0x52]),
                        (~"\ubdc1\u314b\ud7a3", None));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_flush(), (~"", None));
     }
 
     #[test]
     fn test_decoder_valid_partial() {
         let mut d = Windows949Encoding.decoder();
-        assert_result!(d.feed(&[0xb0]), (~"", None));
-        assert_result!(d.feed(&[0xa1]), (~"\uac00", None));
-        assert_result!(d.feed(&[0xb3, 0xaa, 0xb4]), (~"\ub098", None));
-        assert_result!(d.feed(&[0xd9, 0x94]), (~"\ub2e4", None));
-        assert_result!(d.feed(&[0xee, 0xa4, 0xbb, 0xc6, 0x52]), (~"\ubdc1\u314b\ud7a3", None));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_feed(&[0xb0]), (~"", None));
+        assert_result!(d.test_feed(&[0xa1]), (~"\uac00", None));
+        assert_result!(d.test_feed(&[0xb3, 0xaa, 0xb4]), (~"\ub098", None));
+        assert_result!(d.test_feed(&[0xd9, 0x94]), (~"\ub2e4", None));
+        assert_result!(d.test_feed(&[0xee, 0xa4, 0xbb, 0xc6, 0x52]), (~"\ubdc1\u314b\ud7a3", None));
+        assert_result!(d.test_flush(), (~"", None));
     }
 
     #[test]
-    fn test_decoder_invalid_lone_lead_immediate_flush() {
+    fn test_decoder_invalid_lone_lead_immediate_test_flush() {
         for u16::range(0x80, 0x100) |i| {
             let i = i as u8;
             let mut d = Windows949Encoding.decoder();
-            assert_result!(d.feed(&[i]), (~"", None)); // wait for a trail
-            assert_result!(d.flush(), (~"", Some((&[], ~[i]))));
+            assert_result!(d.test_feed(&[i]), (~"", None)); // wait for a trail
+            assert_result!(d.test_flush(), (~"", Some((&[], ~[i]))));
         }
     }
 
@@ -236,8 +234,8 @@ mod euckr_tests {
         for u16::range(0x80, 0x100) |i| {
             let i = i as u8;
             let mut d = Windows949Encoding.decoder();
-            assert_result!(d.feed(&[i, 0x20]), (~"", Some((&[0x20], ~[i]))));
-            assert_result!(d.flush(), (~"", None));
+            assert_result!(d.test_feed(&[i, 0x20]), (~"", Some((&[0x20], ~[i]))));
+            assert_result!(d.test_flush(), (~"", None));
         }
     }
 
@@ -246,9 +244,9 @@ mod euckr_tests {
         for u16::range(0x80, 0x100) |i| {
             let i = i as u8;
             let mut d = Windows949Encoding.decoder();
-            assert_result!(d.feed(&[i, 0x80]), (~"", Some((&[], ~[i, 0x80]))));
-            assert_result!(d.feed(&[i, 0xff]), (~"", Some((&[], ~[i, 0xff]))));
-            assert_result!(d.flush(), (~"", None));
+            assert_result!(d.test_feed(&[i, 0x80]), (~"", Some((&[], ~[i, 0x80]))));
+            assert_result!(d.test_feed(&[i, 0xff]), (~"", Some((&[], ~[i, 0xff]))));
+            assert_result!(d.test_flush(), (~"", None));
         }
     }
 
@@ -258,9 +256,9 @@ mod euckr_tests {
         // note that since the trail byte may coincide with ASCII, the trail byte 53 is
         // not considered to be in the problem. this behavior is intentional.
         let mut d = Windows949Encoding.decoder();
-        assert_result!(d.feed(&[0xc6]), (~"", None));
-        assert_result!(d.feed(&[0x53]), (~"", Some((&[0x53], ~[0xc6]))));
-        assert_result!(d.flush(), (~"", None));
+        assert_result!(d.test_feed(&[0xc6]), (~"", None));
+        assert_result!(d.test_feed(&[0x53]), (~"", Some((&[0x53], ~[0xc6]))));
+        assert_result!(d.test_flush(), (~"", None));
     }
 }
 

--- a/src/whatwg.rs
+++ b/src/whatwg.rs
@@ -3,7 +3,7 @@
 // See README.md and LICENSE.txt for details.
 
 /*!
- * An alternative API compatible to WHATWG Encoding standard. 
+ * An alternative API compatible to WHATWG Encoding standard.
  *
  * WHATWG Encoding standard, compared to the native interface provided by rust-encoding, requires
  * both intentionally different naming of encodings (for example, "EUC-KR" in the standard is
@@ -430,8 +430,7 @@ impl TextDecoder {
                 remaining_.shift();
                 loop {
                     let remaining__ = remaining_;
-                    let (decoded_, err_) = decoder.feed(remaining__);
-                    ret.push_str(decoded_);
+                    let err_ = decoder.feed(remaining__, ret);
                     match err_ {
                         Some(err_) => {
                             ret.push_char('\ufffd');
@@ -443,8 +442,7 @@ impl TextDecoder {
                     }
                 }
 
-                let (decoded, newerr) = decoder.feed(remaining);
-                ret.push_str(decoded);
+                let newerr = decoder.feed(remaining, ret);
                 if newerr.is_none() { return; }
                 err = newerr.unwrap();
             }
@@ -452,16 +450,14 @@ impl TextDecoder {
 
         let mut ret = ~"";
         if feed_first_bytes {
-            let (decoded, err) = self.decoder.feed(self.first_bytes);
-            ret.push_str(decoded);
+            let err = self.decoder.feed(self.first_bytes, &mut ret);
             if err.is_some() {
                 if self.fatal { return Err(~"EncodingError"); }
                 handle_error(&mut self.decoder, err.unwrap(), &mut ret);
             }
         }
         if input.is_some() {
-            let (decoded, err) = self.decoder.feed(input.unwrap());
-            ret.push_str(decoded);
+            let err = self.decoder.feed(input.unwrap(), &mut ret);
             if err.is_some() {
                 if self.fatal { return Err(~"EncodingError"); }
                 handle_error(&mut self.decoder, err.unwrap(), &mut ret);
@@ -474,8 +470,7 @@ impl TextDecoder {
             let mut decoder = self.encoding.decoder();
             swap(&mut decoder, &mut self.decoder);
             loop {
-                let (decoded, err) = decoder.flush(); 
-                ret.push_str(decoded);
+                let err = decoder.flush(&mut ret);
                 if err.is_none() { break; }
                 if self.fatal { return Err(~"EncodingError"); }
                 decoder = self.encoding.decoder();
@@ -528,15 +523,13 @@ impl TextEncoder {
                                       options: TextEncodeOptions) -> Result<~[u8],~str> {
         let mut ret = ~[];
         if input.is_some() {
-            let (encoded, err) = self.encoder.feed(input.unwrap());
-            ret.push_all_move(encoded);
+            let err = self.encoder.feed(input.unwrap(), &mut ret);
             if err.is_some() { return Ok(ret); }
         }
         if !options.stream {
             let mut encoder = self.encoding.encoder();
             swap(&mut encoder, &mut self.encoder);
-            let (encoded, err) = encoder.flush(); 
-            ret.push_all_move(encoded);
+            let err = encoder.flush(&mut ret);
             if err.is_some() { return Ok(ret); }
         }
         Ok(ret)


### PR DESCRIPTION
... instead of returning a newly allocated one.

Add test_feed and test_flush (behind #[cfg(test)]) to avoid refactoring the existing tests. They’re implemented as default methods on the traits, which are still experimental in Rust 0.7 and need a compiler flag to be accepted by the lint pass. They’re not experimental anymore in recent Rust.
