### PR TITLE
Pre-allocate output string/sequences in advance.

### DIFF
--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -25,6 +25,7 @@ impl Encoder for ASCIIEncoder {
     pub fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             if ch <= '\u007f' {
@@ -53,6 +54,7 @@ impl Decoder for ASCIIDecoder {
     pub fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
         while i < len {

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -27,6 +27,7 @@ impl Encoder for EUCJPEncoder {
     pub fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             match ch {
@@ -73,6 +74,7 @@ impl Decoder for EUCJPDecoder {
     pub fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
 
@@ -295,6 +297,7 @@ impl Encoder for ShiftJISEncoder {
     pub fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             match ch {
@@ -339,6 +342,7 @@ impl Decoder for ShiftJISDecoder {
     pub fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
 

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -26,6 +26,7 @@ impl Encoder for Windows949Encoder {
     pub fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             if ch <= '\u007f' {
@@ -71,6 +72,7 @@ impl Decoder for Windows949Decoder {
     pub fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
 

--- a/src/codec/singlebyte.rs
+++ b/src/codec/singlebyte.rs
@@ -38,6 +38,7 @@ impl Encoder for SingleByteEncoder {
     pub fn encoding(&self) -> ~Encoding { ~self.encoding.clone() as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
             if ch <= '\u007f' {
@@ -75,6 +76,7 @@ impl Decoder for SingleByteDecoder {
     pub fn encoding(&self) -> ~Encoding { ~self.encoding.clone() as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
         while i < len {

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -714,6 +714,7 @@ impl Encoder for UTF8Encoder {
     pub fn encoding(&self) -> ~Encoding { ~UTF8Encoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         // in theory `input` should be a valid UTF-8 string, but in reality it may not.
         let err = self.scanner.feed(input.as_bytes(), |s| output.push_all(s));
         err.map_consume(u8_error_to_str_error)
@@ -734,6 +735,7 @@ impl Decoder for UTF8Decoder {
     pub fn encoding(&self) -> ~Encoding { ~UTF8Encoding as ~Encoding }
 
     pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+        { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         self.scanner.feed(input, |s| output.push_str(str::from_bytes(s)))
     }
 


### PR DESCRIPTION
For now just guess that the output will have the same (byte) length as the input. This could be more finely tuned per encoding. This should not affect correctness.
