### PR TITLE
Remove unnecessary publicity specifiers

### DIFF
--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -12,19 +12,19 @@ use types::*;
 pub struct ASCIIEncoding;
 
 impl Encoding for ASCIIEncoding {
-    pub fn name(&self) -> ~str { ~"ascii" }
-    pub fn encoder(&self) -> ~Encoder { ~ASCIIEncoder as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~ASCIIDecoder as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { ~"ascii" }
+    fn encoder(&self) -> ~Encoder { ~ASCIIEncoder as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~ASCIIDecoder as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
 pub struct ASCIIEncoder;
 
 impl Encoder for ASCIIEncoder {
-    pub fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
@@ -42,7 +42,7 @@ impl Encoder for ASCIIEncoder {
         err
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         None
     }
 }
@@ -51,9 +51,9 @@ impl Encoder for ASCIIEncoder {
 pub struct ASCIIDecoder;
 
 impl Decoder for ASCIIDecoder {
-    pub fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~ASCIIEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
@@ -72,7 +72,7 @@ impl Decoder for ASCIIDecoder {
         None
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         None
     }
 }

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -11,19 +11,19 @@ use types::*;
 pub struct ErrorEncoding;
 
 impl Encoding for ErrorEncoding {
-    pub fn name(&self) -> ~str { ~"error" }
-    pub fn encoder(&self) -> ~Encoder { ~ErrorEncoder as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~ErrorDecoder as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { ~"error" }
+    fn encoder(&self) -> ~Encoder { ~ErrorEncoder as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~ErrorDecoder as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
 pub struct ErrorEncoder;
 
 impl Encoder for ErrorEncoder {
-    pub fn encoding(&self) -> ~Encoding { ~ErrorEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~ErrorEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, _output: &mut ~[u8])
+    fn feed<'r>(&mut self, input: &'r str, _output: &mut ~[u8])
                       -> Option<EncoderError<'r>> {
         if input.len() > 0 {
             let str::CharRange {ch, next} = input.char_range_at(0);
@@ -37,7 +37,7 @@ impl Encoder for ErrorEncoder {
         }
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         None
     }
 }
@@ -46,9 +46,9 @@ impl Encoder for ErrorEncoder {
 pub struct ErrorDecoder;
 
 impl Decoder for ErrorDecoder {
-    pub fn encoding(&self) -> ~Encoding { ~ErrorEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~ErrorEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], _output: &mut ~str)
+    fn feed<'r>(&mut self, input: &'r [u8], _output: &mut ~str)
                       -> Option<DecoderError<'r>> {
         if input.len() > 0 {
             Some(CodecError {
@@ -61,7 +61,7 @@ impl Decoder for ErrorDecoder {
         }
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         None
     }
 }

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -14,19 +14,19 @@ use types::*;
 pub struct EUCJPEncoding;
 
 impl Encoding for EUCJPEncoding {
-    pub fn name(&self) -> ~str { ~"euc-jp" }
-    pub fn encoder(&self) -> ~Encoder { ~EUCJPEncoder as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~EUCJPDecoder { first: 0, second: 0 } as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { ~"euc-jp" }
+    fn encoder(&self) -> ~Encoder { ~EUCJPEncoder as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~EUCJPDecoder { first: 0, second: 0 } as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
 pub struct EUCJPEncoder;
 
 impl Encoder for EUCJPEncoder {
-    pub fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
@@ -59,7 +59,7 @@ impl Encoder for EUCJPEncoder {
         err
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         None
     }
 }
@@ -71,9 +71,9 @@ pub struct EUCJPDecoder {
 }
 
 impl Decoder for EUCJPDecoder {
-    pub fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~EUCJPEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
@@ -203,7 +203,7 @@ impl Decoder for EUCJPDecoder {
         None
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         if self.second != 0 {
             Some(CodecError { remaining: &[],
                               problem: ~[0x8f, self.second],
@@ -284,19 +284,19 @@ mod eucjp_tests {
 pub struct ShiftJISEncoding;
 
 impl Encoding for ShiftJISEncoding {
-    pub fn name(&self) -> ~str { ~"shift-jis" }
-    pub fn encoder(&self) -> ~Encoder { ~ShiftJISEncoder as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~ShiftJISDecoder { lead: 0 } as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { ~"shift-jis" }
+    fn encoder(&self) -> ~Encoder { ~ShiftJISEncoder as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~ShiftJISDecoder { lead: 0 } as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
 pub struct ShiftJISEncoder;
 
 impl Encoder for ShiftJISEncoder {
-    pub fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
@@ -328,7 +328,7 @@ impl Encoder for ShiftJISEncoder {
         err
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         None
     }
 }
@@ -339,9 +339,9 @@ pub struct ShiftJISDecoder {
 }
 
 impl Decoder for ShiftJISDecoder {
-    pub fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~ShiftJISEncoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
@@ -419,7 +419,7 @@ impl Decoder for ShiftJISDecoder {
         None
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         if self.lead != 0 {
             Some(CodecError { remaining: &[],
                               problem: ~[self.lead],

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -13,19 +13,19 @@ use types::*;
 pub struct Windows949Encoding;
 
 impl Encoding for Windows949Encoding {
-    pub fn name(&self) -> ~str { ~"windows-949" }
-    pub fn encoder(&self) -> ~Encoder { ~Windows949Encoder as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~Windows949Decoder { lead: 0 } as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { ~"windows-949" }
+    fn encoder(&self) -> ~Encoder { ~Windows949Encoder as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~Windows949Decoder { lead: 0 } as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
 pub struct Windows949Encoder;
 
 impl Encoder for Windows949Encoder {
-    pub fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
@@ -58,7 +58,7 @@ impl Encoder for Windows949Encoder {
         err
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         None
     }
 }
@@ -69,9 +69,9 @@ pub struct Windows949Decoder {
 }
 
 impl Decoder for Windows949Decoder {
-    pub fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~Windows949Encoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
@@ -147,7 +147,7 @@ impl Decoder for Windows949Decoder {
         None
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         if self.lead != 0 {
             Some(CodecError { remaining: &[],
                               problem: ~[self.lead],

--- a/src/codec/singlebyte.rs
+++ b/src/codec/singlebyte.rs
@@ -23,10 +23,10 @@ impl Clone for SingleByteEncoding {
 }
 
 impl Encoding for SingleByteEncoding {
-    pub fn name(&self) -> ~str { self.name.to_owned() }
-    pub fn encoder(&self) -> ~Encoder { ~SingleByteEncoder { encoding: self.clone() } as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~SingleByteDecoder { encoding: self.clone() } as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { self.name.to_owned() }
+    fn encoder(&self) -> ~Encoder { ~SingleByteEncoder { encoding: self.clone() } as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~SingleByteDecoder { encoding: self.clone() } as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
@@ -35,9 +35,9 @@ pub struct SingleByteEncoder {
 }
 
 impl Encoder for SingleByteEncoder {
-    pub fn encoding(&self) -> ~Encoding { ~self.encoding.clone() as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~self.encoding.clone() as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut err = None;
         for input.index_iter().advance |((_,j), ch)| {
@@ -62,7 +62,7 @@ impl Encoder for SingleByteEncoder {
         err
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         None
     }
 }
@@ -73,9 +73,9 @@ pub struct SingleByteDecoder {
 }
 
 impl Decoder for SingleByteDecoder {
-    pub fn encoding(&self) -> ~Encoding { ~self.encoding.clone() as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~self.encoding.clone() as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         let mut i = 0;
         let len = input.len();
@@ -99,7 +99,7 @@ impl Decoder for SingleByteDecoder {
         None
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         None
     }
 }

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -683,10 +683,10 @@ mod scan {
 pub struct UTF8Encoding;
 
 impl Encoding for UTF8Encoding {
-    pub fn name(&self) -> ~str { ~"utf-8" }
-    pub fn encoder(&self) -> ~Encoder { ~UTF8Encoder { scanner: scan::Scanner::new() } as ~Encoder }
-    pub fn decoder(&self) -> ~Decoder { ~UTF8Decoder { scanner: scan::Scanner::new() } as ~Decoder }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+    fn name(&self) -> ~str { ~"utf-8" }
+    fn encoder(&self) -> ~Encoder { ~UTF8Encoder { scanner: scan::Scanner::new() } as ~Encoder }
+    fn decoder(&self) -> ~Decoder { ~UTF8Decoder { scanner: scan::Scanner::new() } as ~Decoder }
+    fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
 }
 
 #[deriving(Clone)]
@@ -711,16 +711,16 @@ fn u8_error_to_str_error<'r>(err: CodecError<&'r [u8],~[u8]>) -> CodecError<&'r 
 }
 
 impl Encoder for UTF8Encoder {
-    pub fn encoding(&self) -> ~Encoding { ~UTF8Encoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~UTF8Encoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         // in theory `input` should be a valid UTF-8 string, but in reality it may not.
         let err = self.scanner.feed(input.as_bytes(), |s| output.push_all(s));
         err.map_consume(u8_error_to_str_error)
     }
 
-    pub fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~[u8]) -> Option<EncoderError<'static>> {
         let mut scanner = self.scanner;
         scanner.flush().map_consume(u8_error_to_str_error)
     }
@@ -732,14 +732,14 @@ pub struct UTF8Decoder {
 }
 
 impl Decoder for UTF8Decoder {
-    pub fn encoding(&self) -> ~Encoding { ~UTF8Encoding as ~Encoding }
+    fn encoding(&self) -> ~Encoding { ~UTF8Encoding as ~Encoding }
 
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>> {
         { let new_len = output.len() + input.len(); output.reserve_at_least(new_len) }
         self.scanner.feed(input, |s| output.push_str(str::from_bytes(s)))
     }
 
-    pub fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
+    fn flush(&mut self, _output: &mut ~str) -> Option<DecoderError<'static>> {
         let mut scanner = self.scanner;
         scanner.flush()
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -100,7 +100,7 @@ mod tests {
         pub struct SurrogateEscape;
         impl<T:Encoding> DecoderTrap<T> for SurrogateEscape {
             // converts invalid single bytes 80..FF to invalid surrogates U+DC80..DCFF
-            pub fn decoder_trap(&mut self, _encoding: &T, input: &[u8]) -> Option<~str> {
+            fn decoder_trap(&mut self, _encoding: &T, input: &[u8]) -> Option<~str> {
                 let chars: ~[char] =
                     input.iter().transform(|&c| (c as uint + 0xdc00) as char).collect();
                 Some(str::from_chars(chars))
@@ -109,7 +109,7 @@ mod tests {
         impl<T:Encoding> EncoderTrap<T> for SurrogateEscape {
             // converts invalid surrogates U+DC80..DCFF back to single bytes 80..FF
             // this is an illustrative example, the actual routine would be a bit more complex.
-            pub fn encoder_trap(&mut self, _encoding: &T, input: &str) -> Option<~[u8]> {
+            fn encoder_trap(&mut self, _encoding: &T, input: &str) -> Option<~[u8]> {
                 let chars: ~[char] = input.iter().collect();
                 if chars.len() == 1 && '\udc80' <= chars[0] && chars[0] <= '\udcff' {
                     Some(~[(chars[0] as uint - 0xdc00) as u8])

--- a/src/types.rs
+++ b/src/types.rs
@@ -27,12 +27,12 @@ pub type DecoderError<'self> = CodecError<&'self [u8],~[u8]>;
 /// normally `Encoding::encode` should be used instead.
 pub trait Encoder: Clone {
     /// Returns a (copy of) encoding implemented by this encoder.
-    pub fn encoding(&self) -> ~Encoding;
+    fn encoding(&self) -> ~Encoding;
     /// Feeds given portion of string to the encoder,
     /// pushes the an encoded byte sequence at the end of the given output,
     /// and returns optional error information. None means success.
-    pub fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>>;
-    #[cfg(test)] pub fn test_feed<'r>(&mut self, input: &'r str) -> (~[u8], Option<EncoderError<'r>>) {
+    fn feed<'r>(&mut self, input: &'r str, output: &mut ~[u8]) -> Option<EncoderError<'r>>;
+    #[cfg(test)] fn test_feed<'r>(&mut self, input: &'r str) -> (~[u8], Option<EncoderError<'r>>) {
         let mut output = ~[];
         let err = self.feed(input, &mut output);
         (output, err)
@@ -41,8 +41,8 @@ pub trait Encoder: Clone {
     /// pushes the an encoded byte sequence at the end of the given output,
     /// and returns optional error information. None means success.
     /// `remaining` value of the error information, if any, is always an empty string.
-    pub fn flush(&mut self, output: &mut ~[u8]) -> Option<EncoderError<'static>>;
-    #[cfg(test)] pub fn test_flush(&mut self) -> (~[u8], Option<EncoderError<'static>>) {
+    fn flush(&mut self, output: &mut ~[u8]) -> Option<EncoderError<'static>>;
+    #[cfg(test)] fn test_flush(&mut self) -> (~[u8], Option<EncoderError<'static>>) {
         let mut output = ~[];
         let err = self.flush(&mut output);
         (output, err)
@@ -53,12 +53,12 @@ pub trait Encoder: Clone {
 /// normally `Encoding::decode` should be used instead.
 pub trait Decoder: Clone {
     /// Returns a (copy of) encoding implemented by this decoder.
-    pub fn encoding(&self) -> ~Encoding;
+    fn encoding(&self) -> ~Encoding;
     /// Feeds given portion of byte sequence to the encoder,
     /// pushes the a decoded string at the end of the given output,
     /// and returns optional error information. None means success.
-    pub fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>>;
-    #[cfg(test)] pub fn test_feed<'r>(&mut self, input: &'r [u8]) -> (~str, Option<DecoderError<'r>>) {
+    fn feed<'r>(&mut self, input: &'r [u8], output: &mut ~str) -> Option<DecoderError<'r>>;
+    #[cfg(test)] fn test_feed<'r>(&mut self, input: &'r [u8]) -> (~str, Option<DecoderError<'r>>) {
         let mut output = ~"";
         let err = self.feed(input, &mut output);
         (output, err)
@@ -67,8 +67,8 @@ pub trait Decoder: Clone {
     /// pushes the a decoded string at the end of the given output,
     /// and returns optional error information. None means success.
     /// `remaining` value of the error information, if any, is always an empty sequence.
-    pub fn flush(&mut self, output: &mut ~str) -> Option<DecoderError<'static>>;
-    #[cfg(test)] pub fn test_flush(&mut self) -> (~str, Option<DecoderError<'static>>) {
+    fn flush(&mut self, output: &mut ~str) -> Option<DecoderError<'static>>;
+    #[cfg(test)] fn test_flush(&mut self) -> (~str, Option<DecoderError<'static>>) {
         let mut output = ~"";
         let err = self.flush(&mut output);
         (output, err)
@@ -78,43 +78,43 @@ pub trait Decoder: Clone {
 /// Character encoding.
 pub trait Encoding {
     /// Returns the canonical name of given encoding.
-    pub fn name(&self) -> ~str;
+    fn name(&self) -> ~str;
     /// Creates a new encoder.
-    pub fn encoder(&self) -> ~Encoder;
+    fn encoder(&self) -> ~Encoder;
     /// Creates a new decoder.
-    pub fn decoder(&self) -> ~Decoder;
+    fn decoder(&self) -> ~Decoder;
     /// Returns a preferred replacement sequence for the encoder. Normally `?` encoded in given
     /// encoding. Note that this is fixed to `"\ufffd"` for the decoder.
-    pub fn preferred_replacement_seq(&self) -> ~[u8];
+    fn preferred_replacement_seq(&self) -> ~[u8];
 }
 
 impl<'self> Encoding for &'self Encoding {
-    pub fn name(&self) -> ~str { (*self).name() }
-    pub fn encoder(&self) -> ~Encoder { (*self).encoder() }
-    pub fn decoder(&self) -> ~Decoder { (*self).decoder() }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { (*self).preferred_replacement_seq() }
+    fn name(&self) -> ~str { (*self).name() }
+    fn encoder(&self) -> ~Encoder { (*self).encoder() }
+    fn decoder(&self) -> ~Decoder { (*self).decoder() }
+    fn preferred_replacement_seq(&self) -> ~[u8] { (*self).preferred_replacement_seq() }
 }
 
 impl Encoding for ~Encoding {
-    pub fn name(&self) -> ~str { (*self).name() }
-    pub fn encoder(&self) -> ~Encoder { (*self).encoder() }
-    pub fn decoder(&self) -> ~Decoder { (*self).decoder() }
-    pub fn preferred_replacement_seq(&self) -> ~[u8] { (*self).preferred_replacement_seq() }
+    fn name(&self) -> ~str { (*self).name() }
+    fn encoder(&self) -> ~Encoder { (*self).encoder() }
+    fn decoder(&self) -> ~Decoder { (*self).decoder() }
+    fn preferred_replacement_seq(&self) -> ~[u8] { (*self).preferred_replacement_seq() }
 }
 
 /// Utilities for character encodings.
 pub trait EncodingUtil<T:Encoding> {
     /// An easy-to-use interface to `Encoder`. On the encoder error `trap` is called, which may
     /// return a replacement sequence to continue processing, or a failure to return the error.
-    pub fn encode<Trap:EncoderTrap<T>>(&self, input: &str, trap: Trap) -> Result<~[u8],~str>;
+    fn encode<Trap:EncoderTrap<T>>(&self, input: &str, trap: Trap) -> Result<~[u8],~str>;
     /// An easy-to-use interface to `Decoder`. On the decoder error `trap` is called, which may
     /// return a replacement string to continue processing, or a failure to return the error.
-    pub fn decode<Trap:DecoderTrap<T>>(&self, input: &[u8], trap: Trap) -> Result<~str,~str>;
+    fn decode<Trap:DecoderTrap<T>>(&self, input: &[u8], trap: Trap) -> Result<~str,~str>;
 }
 
 impl<T:Encoding> EncodingUtil<T> for T {
     #[inline]
-    pub fn encode<Trap:EncoderTrap<T>>(&self, input: &str, mut trap: Trap) -> Result<~[u8],~str> {
+    fn encode<Trap:EncoderTrap<T>>(&self, input: &str, mut trap: Trap) -> Result<~[u8],~str> {
         let mut encoder = self.encoder();
         let mut remaining = input;
         let mut ret = ~[];
@@ -145,7 +145,7 @@ impl<T:Encoding> EncodingUtil<T> for T {
     }
 
     #[inline]
-    pub fn decode<Trap:DecoderTrap<T>>(&self, input: &[u8], mut trap: Trap) -> Result<~str,~str> {
+    fn decode<Trap:DecoderTrap<T>>(&self, input: &[u8], mut trap: Trap) -> Result<~str,~str> {
         let mut decoder = self.decoder();
         let mut remaining = input;
         let mut ret = ~"";
@@ -180,26 +180,26 @@ impl<T:Encoding> EncodingUtil<T> for T {
 /// `EncoderTrap::encoder_trap` is also a valid encoder trap.
 pub trait EncoderTrap<T:Encoding> {
     /// Handles an encoder error. Returns a replacement sequence or gives up by returning `None`.
-    pub fn encoder_trap(&mut self, encoding: &T, input: &str) -> Option<~[u8]>;
+    fn encoder_trap(&mut self, encoding: &T, input: &str) -> Option<~[u8]>;
 }
 
 /// Decoder trap, which handles decoder errors. Note that a function with the same arguments as
 /// `DecoderTrap::decoder_trap` is also a valid decoder trap.
 pub trait DecoderTrap<T:Encoding> {
     /// Handles a decoder error. Returns a replacement string or gives up by returning `None`.
-    pub fn decoder_trap(&mut self, encoding: &T, input: &[u8]) -> Option<~str>;
+    fn decoder_trap(&mut self, encoding: &T, input: &[u8]) -> Option<~str>;
 }
 
 impl<'self,T:Encoding> EncoderTrap<T> for &'self fn(&str) -> ~[u8] {
     #[inline(always)]
-    pub fn encoder_trap(&mut self, _encoding: &T, input: &str) -> Option<~[u8]> {
+    fn encoder_trap(&mut self, _encoding: &T, input: &str) -> Option<~[u8]> {
         Some((*self)(input))
     }
 }
 
 impl<'self,T:Encoding> DecoderTrap<T> for &'self fn(&[u8]) -> ~str {
     #[inline(always)]
-    pub fn decoder_trap(&mut self, _encoding: &T, input: &[u8]) -> Option<~str> {
+    fn decoder_trap(&mut self, _encoding: &T, input: &[u8]) -> Option<~str> {
         Some((*self)(input))
     }
 }
@@ -209,14 +209,14 @@ pub struct Strict;
 
 impl<T:Encoding> EncoderTrap<T> for Strict {
     #[inline]
-    pub fn encoder_trap(&mut self, _encoding: &T, _input: &str) -> Option<~[u8]> {
+    fn encoder_trap(&mut self, _encoding: &T, _input: &str) -> Option<~[u8]> {
         None
     }
 }
 
 impl<T:Encoding> DecoderTrap<T> for Strict {
     #[inline]
-    pub fn decoder_trap(&mut self, _encoding: &T, _input: &[u8]) -> Option<~str> {
+    fn decoder_trap(&mut self, _encoding: &T, _input: &[u8]) -> Option<~str> {
         None
     }
 }
@@ -227,14 +227,14 @@ pub struct Replace;
 
 impl<T:Encoding> EncoderTrap<T> for Replace {
     #[inline]
-    pub fn encoder_trap(&mut self, encoding: &T, _input: &str) -> Option<~[u8]> {
+    fn encoder_trap(&mut self, encoding: &T, _input: &str) -> Option<~[u8]> {
         Some(encoding.preferred_replacement_seq())
     }
 }
 
 impl<T:Encoding> DecoderTrap<T> for Replace {
     #[inline]
-    pub fn decoder_trap(&mut self, _encoding: &T, _input: &[u8]) -> Option<~str> {
+    fn decoder_trap(&mut self, _encoding: &T, _input: &[u8]) -> Option<~str> {
         Some(~"\ufffd")
     }
 }
@@ -244,14 +244,14 @@ pub struct Ignore;
 
 impl<T:Encoding> EncoderTrap<T> for Ignore {
     #[inline]
-    pub fn encoder_trap(&mut self, _encoding: &T, _input: &str) -> Option<~[u8]> {
+    fn encoder_trap(&mut self, _encoding: &T, _input: &str) -> Option<~[u8]> {
         Some(~[])
     }
 }
 
 impl<T:Encoding> DecoderTrap<T> for Ignore {
     #[inline]
-    pub fn decoder_trap(&mut self, _encoding: &T, _input: &[u8]) -> Option<~str> {
+    fn decoder_trap(&mut self, _encoding: &T, _input: &[u8]) -> Option<~str> {
         Some(~"")
     }
 }

--- a/src/whatwg.rs
+++ b/src/whatwg.rs
@@ -33,10 +33,10 @@ mod whatwg_encodings {
     struct ReplacementEncoding;
 
     impl Encoding for ReplacementEncoding {
-        pub fn name(&self) -> ~str { ~"replacement" }
-        pub fn encoder(&self) -> ~Encoder { all::UTF_8.encoder() }
-        pub fn decoder(&self) -> ~Decoder { all::ERROR.decoder() }
-        pub fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
+        fn name(&self) -> ~str { ~"replacement" }
+        fn encoder(&self) -> ~Encoder { all::UTF_8.encoder() }
+        fn decoder(&self) -> ~Decoder { all::ERROR.decoder() }
+        fn preferred_replacement_seq(&self) -> ~[u8] { ~[0x3f] /* "?" */ }
     }
 
     pub static REPLACEMENT: &'static ReplacementEncoding = &ReplacementEncoding;


### PR DESCRIPTION
ie. "pub" in trait implementation.

This is required in rust 0.8-pre, but still compatible with 0.7.
