### PR TITLE
Split Trap into DecoderTrap and EncoderTrap.

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -84,19 +84,19 @@ mod tests {
 
     #[test]
     fn test_readme() {
-        assert_eq!(all::ISO_8859_1.encode("caf\xe9", Strict), Ok(~[99,97,102,233]));
+        assert_eq!(all::ISO_8859_1.encode("caf\xe9", EncodeStrict), Ok(~[99,97,102,233]));
 
-        assert!(all::ISO_8859_2.encode("Acme\xa9", Strict).is_err());
-        assert_eq!(all::ISO_8859_2.encode("Acme\xa9", Replace), Ok(~[65,99,109,101,63]));
-        assert_eq!(all::ISO_8859_2.encode("Acme\xa9", Ignore), Ok(~[65,99,109,101]));
-        assert_eq!(all::ISO_8859_2.encode("Acme\xa9", NcrEscape),
+        assert!(all::ISO_8859_2.encode("Acme\xa9", EncodeStrict).is_err());
+        assert_eq!(all::ISO_8859_2.encode("Acme\xa9", EncodeReplace), Ok(~[65,99,109,101,63]));
+        assert_eq!(all::ISO_8859_2.encode("Acme\xa9", EncodeIgnore), Ok(~[65,99,109,101]));
+        assert_eq!(all::ISO_8859_2.encode("Acme\xa9", EncodeNcrEscape),
                    Ok(~[65,99,109,101,38,35,49,54,57,59])); // Acme&#169;
 
-        assert_eq!(all::ISO_8859_1.decode([99,97,102,233], Strict), Ok(~"caf\xe9"));
+        assert_eq!(all::ISO_8859_1.decode([99,97,102,233], DecodeStrict), Ok(~"caf\xe9"));
 
-        assert!(all::ISO_8859_6.decode([65,99,109,101,169], Strict).is_err());
-        assert_eq!(all::ISO_8859_6.decode([65,99,109,101,169], Replace), Ok(~"Acme\ufffd"));
-        assert_eq!(all::ISO_8859_6.decode([65,99,109,101,169], Ignore), Ok(~"Acme"));
+        assert!(all::ISO_8859_6.decode([65,99,109,101,169], DecodeStrict).is_err());
+        assert_eq!(all::ISO_8859_6.decode([65,99,109,101,169], DecodeReplace), Ok(~"Acme\ufffd"));
+        assert_eq!(all::ISO_8859_6.decode([65,99,109,101,169], DecodeIgnore), Ok(~"Acme"));
     }
 
     #[test]
@@ -109,11 +109,10 @@ mod tests {
             output.write_bytes(escapes.as_bytes());
             true
         }
-        static HexNcrEscape: Trap = EncoderTrap(hex_ncr_escape);
-
+        let HexNcrEscape = EncoderTrap(hex_ncr_escape);
         let orig = ~"Hello, 世界!";
         let encoded = all::ASCII.encode(orig, HexNcrEscape).unwrap();
-        let decoded = all::ASCII.decode(encoded, Strict).unwrap();
+        let decoded = all::ASCII.decode(encoded, DecodeStrict).unwrap();
         assert_eq!(decoded, ~"Hello, &#x4e16;&#x754c;!");
     }
 
@@ -123,10 +122,10 @@ mod tests {
         assert_eq!(euckr.name(), "windows-949");
         assert_eq!(euckr.whatwg_name(), Some("euc-kr")); // for the sake of compatibility
         let broken = &[0xbf, 0xec, 0xbf, 0xcd, 0xff, 0xbe, 0xd3];
-        assert_eq!(euckr.decode(broken, Replace), Ok(~"\uc6b0\uc640\ufffd\uc559"));
+        assert_eq!(euckr.decode(broken, DecodeReplace), Ok(~"\uc6b0\uc640\ufffd\uc559"));
 
         // corresponding rust-encoding native API:
-        assert_eq!(all::WINDOWS_949.decode(broken, Replace), Ok(~"\uc6b0\uc640\ufffd\uc559"));
+        assert_eq!(all::WINDOWS_949.decode(broken, DecodeReplace), Ok(~"\uc6b0\uc640\ufffd\uc559"));
     }
 }
 


### PR DESCRIPTION
This prevents through the type system using an encoder-only trap for decoding, rather than having runtime failures.

It’s only when starting to make this change that I noticed that the variants in common in both had to be disambiguated. I added prefixes, but it makes the API a bit ugly to use so I’m not sure it’s worth it. What do you think?
