### PR TITLE
Replace glob reexport

### DIFF
--- a/src/encoding/lib.rs
+++ b/src/encoding/lib.rs
@@ -15,7 +15,10 @@
 
 #![feature(globs, macro_rules)]
 
-pub use self::types::*; // reexport
+pub use self::types::{CodecError, ByteWriter, StringWriter,
+                      Encoder, Decoder, EncodingRef, Encoding,
+                      EncoderTrapFunc, DecoderTrapFunc, DecoderTrap,
+                      EncoderTrap, decode}; // reexport
 
 mod util;
 #[cfg(test)] mod testutils;


### PR DESCRIPTION
[`pub use .... ::*` type globs are being removed](https://github.com/mozilla/rust/issues/11870)
 in Rust.

This is part of [mozilla/servo #2131](https://github.com/mozilla/servo/issues/2131)
