### PR TITLE
Rebuild when external dependencies change

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -7,6 +7,7 @@ AR ?= ar
 RUSTC ?= rustc
 RUSTDOC ?= rustdoc
 RUSTFLAGS ?= -O
+EXT_DEPS ?=
 
 LIB_RS = src/encoding/lib.rs
 RUST_SRC = $(shell find $(VPATH)/src/encoding/. -type f -name '*.rs')
@@ -14,7 +15,7 @@ RUST_SRC = $(shell find $(VPATH)/src/encoding/. -type f -name '*.rs')
 .PHONY: all
 all:	libencoding.dummy
 
-libencoding.dummy: $(LIB_RS) $(RUST_SRC)
+libencoding.dummy: $(LIB_RS) $(RUST_SRC) $(EXT_DEPS)
 	$(RUSTC) $(RUSTFLAGS) $< --out-dir .
 	touch $@
 


### PR DESCRIPTION
Depends on mozilla/servo#2472.  This lets the Servo build system set an $EXT_DEPS environment variable so that libencoding will be recompiled correctly after the libraries it depends on are rebuilt.
