### PR TITLE
Rename Share trait to Sync, as per master.

### DIFF
--- a/src/encoding/types.rs
+++ b/src/encoding/types.rs
@@ -246,7 +246,7 @@ pub trait Decoder {
 /// A trait object using dynamic dispatch which is a sendable reference to the encoding,
 /// for code where the encoding is not known at compile-time.
 #[stable]
-pub type EncodingRef = &'static Encoding+Send+Share;
+pub type EncodingRef = &'static Encoding + Send + Sync;
 
 /// Character encoding.
 #[stable]


### PR DESCRIPTION
The nightlies have started using `Sync` instead of `Share`.

Closes #34.
