### PR TITLE
Fix building with current rust

### DIFF
--- a/src/encoding/label.rs
+++ b/src/encoding/label.rs
@@ -12,9 +12,7 @@ use types::EncodingRef;
 /// Implements "get an encoding" algorithm: http://encoding.spec.whatwg.org/#decode
 #[stable]
 pub fn encoding_from_whatwg_label(label: &str) -> Option<EncodingRef> {
-    // FIXME(rust#10683): temp needed as workaround
-    let trimmed = label.trim_chars(&[' ', '\n', '\r', '\t', '\x0C']).to_ascii_lower();
-    match trimmed.as_slice() {
+    match label.trim_chars([' ', '\n', '\r', '\t', '\x0C'].as_slice()).to_ascii_lower().as_slice() {
         "unicode-1-1-utf-8" |
         "utf-8" |
         "utf8" =>


### PR DESCRIPTION
By now, #10683 has been fixed, so the temporary can be dropped, but
with the DST changes, we now get &[char, ..5], which doesn't coerce to
&[char]. And since only the latter implements CharEq, we have a problem.
Using as_slice() instead of prefixing the vector with &, we get a
&[char] and all is good.
