### PR TITLE
Fix build break due to generalized object bounds

### DIFF
--- a/src/encoding/types.rs
+++ b/src/encoding/types.rs
@@ -102,7 +102,7 @@ impl ByteWriter for Vec<u8> {
 
 /// String writer used by `Decoder`s. In most cases this will be an owned string.
 #[unstable]
-pub trait StringWriter {
+pub trait StringWriter: 'static {
     /// Hints an expected lower bound on the length (in bytes) of the output
     /// until the next call to `writer_hint`,
     /// so that the writer can reserve the memory for writing.
@@ -136,7 +136,7 @@ impl StringWriter for String {
 /// Encoder converting a Unicode string into a byte sequence.
 /// This is a lower level interface, and normally `Encoding::encode` should be used instead.
 #[experimental]
-pub trait Encoder {
+pub trait Encoder: 'static {
     /// Creates a fresh `Encoder` instance which parameters are same as `self`.
     fn from_self(&self) -> Box<Encoder>;
 
@@ -189,7 +189,7 @@ pub trait Encoder {
 /// Encoder converting a byte sequence into a Unicode string.
 /// This is a lower level interface, and normally `Encoding::decode` should be used instead.
 #[experimental]
-pub trait Decoder {
+pub trait Decoder: 'static {
     /// Creates a fresh `Decoder` instance which parameters are same as `self`.
     fn from_self(&self) -> Box<Decoder>;
 


### PR DESCRIPTION
This adds the 'static bound directly to the traits to avoid code churn for now.  I'm not sure if you ever want to take advantage of trait boxes with more specific bounds.
