### PR TITLE
Crate no longer compiles with `..` character ranges.

### DIFF
--- a/src/encoding/codec/korean.rs
+++ b/src/encoding/codec/korean.rs
@@ -89,13 +89,13 @@ ascii_compatible_stateful_decoder! {
         let lead = lead as uint;
         let trail = trail as uint;
         let index = match (lead, trail) {
-            (0x81..0xc6, 0x41..0x5a) =>
+            (0x81...0xc6, 0x41...0x5a) =>
                 (26 + 26 + 126) * (lead - 0x81) + trail - 0x41,
-            (0x81..0xc6, 0x61..0x7a) =>
+            (0x81...0xc6, 0x61...0x7a) =>
                 (26 + 26 + 126) * (lead - 0x81) + 26 + trail - 0x61,
-            (0x81..0xc6, 0x81..0xfe) =>
+            (0x81...0xc6, 0x81...0xfe) =>
                 (26 + 26 + 126) * (lead - 0x81) + 26 + 26 + trail - 0x81,
-            (0xc7..0xfe, 0xa1..0xfe) =>
+            (0xc7...0xfe, 0xa1...0xfe) =>
                 (26 + 26 + 126) * (0xc7 - 0x81) + (lead - 0xc7) * 94 + trail - 0xa1,
             (_, _) => 0xffff,
         };
@@ -104,8 +104,8 @@ ascii_compatible_stateful_decoder! {
 
     // euc-kr lead = 0x00
     initial state S0(ctx) {
-        case b @ 0x00..0x7f => ctx.emit(b as u32);
-        case b @ 0x81..0xfe => S1(ctx, b);
+        case b @ 0x00...0x7f => ctx.emit(b as u32);
+        case b @ 0x81...0xfe => S1(ctx, b);
         case _ => ctx.err("invalid sequence");
     }
 

--- a/src/encoding/codec/simpchinese.rs
+++ b/src/encoding/codec/simpchinese.rs
@@ -101,7 +101,7 @@ ascii_compatible_stateful_decoder! {
         let lead = lead as uint;
         let trail = trail as uint;
         let index = match (lead, trail) {
-            (0x81..0xfe, 0x40..0x7e) | (0x81..0xfe, 0x80..0xfe) => {
+            (0x81...0xfe, 0x40...0x7e) | (0x81...0xfe, 0x80...0xfe) => {
                 let trailoffset = if trail < 0x7f {0x40} else {0x41};
                 (lead - 0x81) * 190 + trail - trailoffset
             }
@@ -121,15 +121,15 @@ ascii_compatible_stateful_decoder! {
 
     // gb18030 first = 0x00, gb18030 second = 0x00, gb18030 third = 0x00
     initial state S0(ctx) {
-        case b @ 0x00..0x7f => ctx.emit(b as u32);
+        case b @ 0x00...0x7f => ctx.emit(b as u32);
         case 0x80 => ctx.emit(0x20ac);
-        case b @ 0x81..0xfe => S1(ctx, b);
+        case b @ 0x81...0xfe => S1(ctx, b);
         case _ => ctx.err("invalid sequence");
     }
 
     // gb18030 first != 0x00, gb18030 second = 0x00, gb18030 third = 0x00
     state S1(ctx, first: u8) {
-        case b @ 0x30..0x39 => S2(ctx, first, b);
+        case b @ 0x30...0x39 => S2(ctx, first, b);
         case b => match map_two_bytes(first, b) {
             0xffff => ctx.backup_and_err(1, "invalid sequence"), // unconditional
             ch => ctx.emit(ch)
@@ -138,13 +138,13 @@ ascii_compatible_stateful_decoder! {
 
     // gb18030 first != 0x00, gb18030 second != 0x00, gb18030 third = 0x00
     state S2(ctx, first: u8, second: u8) {
-        case b @ 0x81..0xfe => S3(ctx, first, second, b);
+        case b @ 0x81...0xfe => S3(ctx, first, second, b);
         case _ => ctx.backup_and_err(2, "invalid sequence");
     }
 
     // gb18030 first != 0x00, gb18030 second != 0x00, gb18030 third != 0x00
     state S3(ctx, first: u8, second: u8, third: u8) {
-        case b @ 0x30..0x39 => match map_four_bytes(first, second, third, b) {
+        case b @ 0x30...0x39 => match map_four_bytes(first, second, third, b) {
             0xffffffff => ctx.backup_and_err(3, "invalid sequence"), // unconditional
             ch => ctx.emit(ch)
         };
@@ -418,7 +418,7 @@ stateful_decoder! {
         let lead = lead as uint;
         let trail = trail as uint;
         let index = match (lead, trail) {
-            (0x20..0x7f, 0x21..0x7e) => (lead - 1) * 190 + (trail + 0x3f),
+            (0x20...0x7f, 0x21...0x7e) => (lead - 1) * 190 + (trail + 0x3f),
             _ => 0xffff,
         };
         index::gb18030::forward(index as u16)
@@ -427,7 +427,7 @@ stateful_decoder! {
     // hz-gb-2312 flag = unset, hz-gb-2312 lead = 0x00
     initial state A0(ctx) {
         case 0x7e => A1(ctx);
-        case b @ 0x00..0x7f => ctx.emit(b as u32);
+        case b @ 0x00...0x7f => ctx.emit(b as u32);
         case _ => ctx.err("invalid sequence");
         final => ctx.reset();
     }
@@ -435,7 +435,7 @@ stateful_decoder! {
     // hz-gb-2312 flag = set, hz-gb-2312 lead = 0x00
     checkpoint state B0(ctx) {
         case 0x7e => B1(ctx);
-        case b @ 0x20..0x7f => B2(ctx, b);
+        case b @ 0x20...0x7f => B2(ctx, b);
         case 0x0a => ctx.err("invalid sequence"); // error *and* reset
         case _ => ctx.err("invalid sequence"), B0(ctx);
         final => ctx.reset();

--- a/src/encoding/codec/tradchinese.rs
+++ b/src/encoding/codec/tradchinese.rs
@@ -53,7 +53,7 @@ impl Encoder for BigFive2003Encoder {
             } else {
                 let ptr = index::big5::backward(ch as u32);
                 if ptr == 0xffff || ptr < (0xa1 - 0x81) * 157 {
-                    // no HKSCS extension (XXX doesn't HKSCS include 0xFA40..0xFEFE?)
+                    // no HKSCS extension (XXX doesn't HKSCS include 0xFA40...0xFEFE?)
                     return (i, Some(CodecError {
                         upto: j as int, cause: "unrepresentable character".into_maybe_owned()
                     }));
@@ -86,19 +86,19 @@ ascii_compatible_stateful_decoder! {
         let lead = lead as uint;
         let trail = trail as uint;
         let index = match (lead, trail) {
-            (0x81..0xfe, 0x40..0x7e) | (0x81..0xfe, 0xa1..0xfe) => {
+            (0x81...0xfe, 0x40...0x7e) | (0x81...0xfe, 0xa1...0xfe) => {
                 let trailoffset = if trail < 0x7f {0x40} else {0x62};
                 (lead - 0x81) * 157 + trail - trailoffset
             }
             _ => 0xffff,
         };
-        index::big5::forward(index as u16) // may return two-letter replacements 0..3
+        index::big5::forward(index as u16) // may return two-letter replacements 0...3
     }
 
     // big5 lead = 0x00
     initial state S0(ctx) {
-        case b @ 0x00..0x7f => ctx.emit(b as u32);
-        case b @ 0x81..0xfe => S1(ctx, b);
+        case b @ 0x00...0x7f => ctx.emit(b as u32);
+        case b @ 0x81...0xfe => S1(ctx, b);
         case _ => ctx.err("invalid sequence");
     }
 

--- a/src/encoding/codec/utf_16.rs
+++ b/src/encoding/codec/utf_16.rs
@@ -60,7 +60,7 @@ impl Endian for Big {
  * 2 (up to U+FFFF) or 4 bytes (up to U+10FFFF) depending on its value.
  * It uses a "surrogate" mechanism to encode non-BMP codepoints,
  * which are represented as a pair of lower surrogate and upper surrogate characters.
- * In this effect, surrogate characters (U+D800..DFFF) cannot appear alone
+ * In this effect, surrogate characters (U+D800...DFFF) cannot appear alone
  * and cannot be included in a valid Unicode string.
  *
  * ## Specialization
@@ -110,10 +110,10 @@ impl<E:Endian+Clone+'static> Encoder for UTF16Encoder<E> {
         for ((i,j), ch) in input.index_iter() {
             let ch = ch as uint;
             match ch {
-                0x0000..0xd7ff | 0xe000..0xffff => {
+                0x0000...0xd7ff | 0xe000...0xffff => {
                     write_two_bytes(output, (ch >> 8) as u8, (ch & 0xff) as u8);
                 }
-                0x10000..0x10ffff => {
+                0x10000...0x10ffff => {
                     let ch = ch - 0x10000;
                     write_two_bytes(output, (0xd8 | (ch >> 18)) as u8,
                                             ((ch >> 10) & 0xff) as u8);
@@ -158,7 +158,7 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
     fn from_self(&self) -> Box<Decoder> { UTF16Decoder::new(None::<E>) }
 
     fn raw_feed(&mut self, input: &[u8], output: &mut StringWriter) -> (uint, Option<CodecError>) {
-        output.writer_hint(input.len() / 2); // when every codepoint is U+0000..007F
+        output.writer_hint(input.len() / 2); // when every codepoint is U+0000...007F
 
         let concat_two_bytes = |lead: u16, trail: u8|
             Endian::concat_two_bytes(None::<E>, lead, trail);
@@ -177,7 +177,7 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
                 let upper = self.leadsurrogate;
                 self.leadsurrogate = 0xffff;
                 match ch {
-                    0xdc00..0xdfff => {
+                    0xdc00...0xdfff => {
                         let ch = ((upper as uint - 0xd800) << 10) + (ch as uint - 0xdc00);
                         output.write_char(as_char(ch + 0x10000));
                         processed = i;
@@ -190,11 +190,11 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
                 }
             } else {
                 match ch {
-                    0xd800..0xdbff => {
+                    0xd800...0xdbff => {
                         self.leadsurrogate = ch;
                         // pass through
                     }
-                    0xdc00..0xdfff => {
+                    0xdc00...0xdfff => {
                         return (processed, Some(CodecError {
                             upto: i as int, cause: "invalid sequence".into_maybe_owned()
                         }));
@@ -218,7 +218,7 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
             let ch = concat_two_bytes(input[i-1] as u16, input[i]);
             i += 1;
             match ch {
-                0xdc00..0xdfff => {
+                0xdc00...0xdfff => {
                     let ch = ((upper as uint - 0xd800) << 10) + (ch as uint - 0xdc00);
                     output.write_char(as_char(ch + 0x10000));
                 }
@@ -243,7 +243,7 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
             }
             let ch = concat_two_bytes(input[i-1] as u16, input[i]);
             match ch {
-                0xd800..0xdbff => {
+                0xd800...0xdbff => {
                     i += 2;
                     if i >= len {
                         self.leadsurrogate = ch;
@@ -252,7 +252,7 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
                     }
                     let ch2 = concat_two_bytes(input[i-1] as u16, input[i]);
                     match ch2 {
-                        0xdc00..0xdfff => {
+                        0xdc00...0xdfff => {
                             let ch = ((ch as uint - 0xd800) << 10) + (ch2 as uint - 0xdc00);
                             output.write_char(as_char(ch + 0x10000));
                         }
@@ -263,7 +263,7 @@ impl<E:Endian+Clone+'static> Decoder for UTF16Decoder<E> {
                         }
                     }
                 }
-                0xdc00..0xdfff => {
+                0xdc00...0xdfff => {
                     return (processed, Some(CodecError {
                         upto: i as int + 1, cause: "invalid sequence".into_maybe_owned()
                     }));


### PR DESCRIPTION
Ranges must use the `...` syntax as of [rust PR #17584](https://github.com/rust-lang/rust/pull/17584)

Passes `cargo build` and `cargo test`.
_Tested locally with `rustc 0.12.0-dev (8ab6fce95 2014-10-01 11:27:23 +0000)` and `cargo 0.0.1-pre (4ee87de 2014-09-08 17:58:56 +0000)`._
