### PR TITLE
Make index_tests.rs its own crate, used by the other index-* crates.

### DIFF
--- a/src/index/japanese/Cargo.toml
+++ b/src/index/japanese/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 name = "encoding-index-japanese"
 path = "lib.rs"
 
+[dependencies.encoding_index_tests]
+path = "../tests"

--- a/src/index/japanese/lib.rs
+++ b/src/index/japanese/lib.rs
@@ -5,11 +5,11 @@
 
 //! Japanese index tables for [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(macro_rules)]
+#![feature(phase)]
 
 #[cfg(test)]
-#[path = "../index_tests.rs"]
-mod tests;
+#[phase(plugin)]
+extern crate encoding_index_tests;
 
 /// JIS X 0208 with common extensions.
 ///

--- a/src/index/korean/Cargo.toml
+++ b/src/index/korean/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 name = "encoding-index-korean"
 path = "lib.rs"
 
+[dependencies.encoding_index_tests]
+path = "../tests"

--- a/src/index/korean/lib.rs
+++ b/src/index/korean/lib.rs
@@ -5,11 +5,11 @@
 
 //! Korean index tables for [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(macro_rules)]
+#![feature(phase)]
 
 #[cfg(test)]
-#[path = "../index_tests.rs"]
-mod tests;
+#[phase(plugin)]
+extern crate encoding_index_tests;
 
 /// KS X 1001 plus Unified Hangul Code.
 ///

--- a/src/index/simpchinese/Cargo.toml
+++ b/src/index/simpchinese/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 name = "encoding-index-simpchinese"
 path = "lib.rs"
 
+[dependencies.encoding_index_tests]
+path = "../tests"

--- a/src/index/simpchinese/lib.rs
+++ b/src/index/simpchinese/lib.rs
@@ -6,11 +6,11 @@
 //! Simplified Chinese index tables for
 //! [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(macro_rules)]
+#![feature(phase)]
 
 #[cfg(test)]
-#[path = "../index_tests.rs"]
-mod tests;
+#[phase(plugin)]
+extern crate encoding_index_tests;
 
 /// GB 18030 two-byte area.
 ///

--- a/src/index/singlebyte/Cargo.toml
+++ b/src/index/singlebyte/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 name = "encoding-index-singlebyte"
 path = "lib.rs"
 
+[dependencies.encoding_index_tests]
+path = "../tests"

--- a/src/index/singlebyte/lib.rs
+++ b/src/index/singlebyte/lib.rs
@@ -6,11 +6,11 @@
 //! Single-byte index tables for
 //! [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(macro_rules)]
+#![feature(phase)]
 
 #[cfg(test)]
-#[path = "../index_tests.rs"]
-mod tests;
+#[phase(plugin)]
+extern crate encoding_index_tests;
 
 /// IBM code page 866.
 #[stable] pub mod ibm866;

--- a/src/index/tests/Cargo.toml
+++ b/src/index/tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "encoding_index_tests"
+version = "0.1.0"
+authors = ["Kang Seonghoon <public+rust@mearie.org>"]
+
+[lib]
+name = "encoding_index_tests"
+path = "index_tests.rs"

--- a/src/index/tests/index_tests.rs
+++ b/src/index/tests/index_tests.rs
@@ -4,9 +4,10 @@
 
 //! Macros and utilities for testing indices.
 
-#![macro_escape]
+#![feature(macro_rules)]
 
 /// Makes a common test suite for single-byte indices.
+#[macro_export]
 macro_rules! single_byte_tests(
     () => (
         mod tests {
@@ -46,6 +47,7 @@ macro_rules! single_byte_tests(
 )
 
 /// Makes a common test suite for multi-byte indices.
+#[macro_export]
 macro_rules! multi_byte_tests(
     (make shared tests and benches with dups = $dups:expr) => ( // internal macro
         #[test]
@@ -136,6 +138,7 @@ macro_rules! multi_byte_tests(
 )
 
 /// Makes a common test suite for multi-byte range indices.
+#[macro_export]
 macro_rules! multi_byte_range_tests(
     (
         key = $minkey:expr .. $maxkey:expr, key < $keyubound:expr,

--- a/src/index/tradchinese/Cargo.toml
+++ b/src/index/tradchinese/Cargo.toml
@@ -7,3 +7,5 @@ authors = ["Kang Seonghoon <public+rust@mearie.org>"]
 name = "encoding-index-tradchinese"
 path = "lib.rs"
 
+[dependencies.encoding_index_tests]
+path = "../tests"

--- a/src/index/tradchinese/lib.rs
+++ b/src/index/tradchinese/lib.rs
@@ -6,11 +6,11 @@
 //! Traditional Chinese index tables for
 //! [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(macro_rules)]
+#![feature(phase)]
 
 #[cfg(test)]
-#[path = "../index_tests.rs"]
-mod tests;
+#[phase(plugin)]
+extern crate encoding_index_tests;
 
 /// Big5 and HKSCS.
 ///


### PR DESCRIPTION
Avoid using

``` rust
#[path = "../index_tests.rs"]
mod tests;
```

… which doesn’t work nicely with crates.io.
