### PR TITLE
Import Correct Names in Tests

### DIFF
--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -101,6 +101,10 @@ mod tests {
     use super::ASCIIEncoding;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Replace as DecodeReplace;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
+    use types::EncoderTrap::Replace as EncodeReplace;
 
     #[test]
     fn test_encoder() {

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -165,6 +165,8 @@ mod eucjp_tests {
     use std::iter::range_inclusive;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {
@@ -521,6 +523,8 @@ mod windows31j_tests {
     use std::iter::range_inclusive;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {
@@ -918,6 +922,9 @@ mod iso2022jp_tests {
     use super::ISO2022JPEncoding;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Replace as DecodeReplace;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -125,6 +125,8 @@ mod windows949_tests {
     use std::iter::range_inclusive;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {

--- a/src/codec/simpchinese.rs
+++ b/src/codec/simpchinese.rs
@@ -158,6 +158,8 @@ mod gb18030_tests {
     use super::GB18030Encoding;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {
@@ -479,6 +481,8 @@ mod hz_tests {
     use super::HZEncoding;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {

--- a/src/codec/tradchinese.rs
+++ b/src/codec/tradchinese.rs
@@ -125,6 +125,8 @@ mod bigfive2003_tests {
     use std::iter::range_inclusive;
     use testutils;
     use types::*;
+    use types::DecoderTrap::Strict as DecodeStrict;
+    use types::EncoderTrap::Strict as EncodeStrict;
 
     #[test]
     fn test_encoder_valid() {

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -638,6 +638,8 @@ mod tests {
         use std::str;
         use testutils;
         use types::*;
+        use types::DecoderTrap::Strict as DecodeStrict;
+        use types::EncoderTrap::Strict as EncodeStrict;
 
         #[bench]
         fn bench_encode(bencher: &mut test::Bencher) {
@@ -693,6 +695,8 @@ mod tests {
         use std::str;
         use testutils;
         use types::*;
+        use types::DecoderTrap::Strict as DecodeStrict;
+        use types::EncoderTrap::Strict as EncodeStrict;
 
         #[bench]
         fn bench_encode(bencher: &mut test::Bencher) {
@@ -746,6 +750,7 @@ mod tests {
         use std::str;
         use testutils;
         use types::*;
+        use types::DecoderTrap::Replace as DecodeReplace;
 
         #[bench]
         fn bench_decode_replace(bencher: &mut test::Bencher) {
@@ -790,6 +795,7 @@ mod tests {
         use std::str;
         use testutils;
         use types::*;
+        use types::DecoderTrap::Replace as DecodeReplace;
 
         #[bench]
         fn bench_decode_replace(bencher: &mut test::Bencher) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -467,6 +467,7 @@ pub fn decode(input: &[u8], trap: DecoderTrap, fallback_encoding: EncodingRef)
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::EncoderTrap::NcrEscape;
     use util::StrCharIndex;
 
     // a contrived encoding example: same as ASCII, but inserts `prepend` between each character
@@ -521,9 +522,9 @@ mod tests {
         static INCOMPAT: &'static MyEncoding =
             &MyEncoding { flag: false, prohibit: '\u0080', prepend: "" };
 
-        assert_eq!(COMPAT.encode("Hello\u203d I'm fine.", EncodeNcrEscape),
+        assert_eq!(COMPAT.encode("Hello\u203d I'm fine.", NcrEscape),
                    Ok(b"Hello&#8253; I'm fine.".to_vec()));
-        assert_eq!(INCOMPAT.encode("Hello\u203d I'm fine.", EncodeNcrEscape),
+        assert_eq!(INCOMPAT.encode("Hello\u203d I'm fine.", NcrEscape),
                    Ok(b"Hello&#8253; I'm fine.".to_vec()));
     }
 
@@ -535,9 +536,9 @@ mod tests {
             &MyEncoding { flag: false, prohibit: '\u0080', prepend: "*" };
 
         // this should behave incorrectly as the encoding broke the assumption.
-        assert_eq!(COMPAT.encode("Hello\u203d I'm fine.", EncodeNcrEscape),
+        assert_eq!(COMPAT.encode("Hello\u203d I'm fine.", NcrEscape),
                    Ok(b"He*l*l*o&#8253;* *I*'*m* *f*i*n*e.".to_vec()));
-        assert_eq!(INCOMPAT.encode("Hello\u203d I'm fine.", EncodeNcrEscape),
+        assert_eq!(INCOMPAT.encode("Hello\u203d I'm fine.", NcrEscape),
                    Ok(b"He*l*l*o*&*#*8*2*5*3*;* *I*'*m* *f*i*n*e.".to_vec()));
     }
 
@@ -547,6 +548,6 @@ mod tests {
         static FAIL: &'static MyEncoding = &MyEncoding { flag: false, prohibit: '&', prepend: "" };
 
         // this should fail as this contrived encoding does not support `&` at all
-        let _ = FAIL.encode("Hello\u203d I'm fine.", EncodeNcrEscape);
+        let _ = FAIL.encode("Hello\u203d I'm fine.", NcrEscape);
     }
 }


### PR DESCRIPTION
The tests were previously failing to compile due to name mismatches; these now compile and pass.
