### PR TITLE
Build against rust 20150103

### DIFF
--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -5,6 +5,7 @@
 //! 7-bit ASCII encoding.
 
 use std::{str, mem};
+use std::borrow::IntoCow;
 use types::*;
 
 /**

--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -14,7 +14,7 @@ use types::*;
  * It is both a basis and a lowest common denominator of many other encodings
  * including UTF-8, which Rust internally assumes.
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ASCIIEncoding;
 
 impl Encoding for ASCIIEncoding {
@@ -24,7 +24,7 @@ impl Encoding for ASCIIEncoding {
 }
 
 /// An encoder for ASCII.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ASCIIEncoder;
 
 impl ASCIIEncoder {
@@ -59,7 +59,7 @@ impl RawEncoder for ASCIIEncoder {
 }
 
 /// A decoder for ASCII.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ASCIIDecoder;
 
 impl ASCIIDecoder {

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -5,6 +5,7 @@
 //! A placeholder encoding that returns encoder/decoder error for every case.
 
 use std::str;
+use std::borrow::IntoCow;
 use types::*;
 
 /// An encoding that returns encoder/decoder error for every case.

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -9,7 +9,7 @@ use std::borrow::IntoCow;
 use types::*;
 
 /// An encoding that returns encoder/decoder error for every case.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ErrorEncoding;
 
 impl Encoding for ErrorEncoding {
@@ -19,7 +19,7 @@ impl Encoding for ErrorEncoding {
 }
 
 /// An encoder that always returns error.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ErrorEncoder;
 
 impl ErrorEncoder {
@@ -45,7 +45,7 @@ impl RawEncoder for ErrorEncoder {
 }
 
 /// A decoder that always returns error.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ErrorDecoder;
 
 impl ErrorDecoder {

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -4,6 +4,7 @@
 
 //! Legacy Japanese encodings based on JIS X 0208 and JIS X 0212.
 
+use std::borrow::IntoCow;
 use util::StrCharIndex;
 use index_japanese as index;
 use types::*;

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -25,7 +25,7 @@ use self::ISO2022JPState::{ASCII,Katakana,Lead};
  * the upper half of JIS X 0212 in G2 (`8E [A1-DF]`), and
  * JIS X 0212 in G3 (`8F [A1-FE] [A1-FE]`).
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct EUCJPEncoding;
 
 impl Encoding for EUCJPEncoding {
@@ -36,7 +36,7 @@ impl Encoding for EUCJPEncoding {
 }
 
 /// An encoder for EUC-JP with unused G3 character set.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct EUCJPEncoder;
 
 impl EUCJPEncoder {
@@ -84,7 +84,7 @@ impl RawEncoder for EUCJPEncoder {
 
 ascii_compatible_stateful_decoder! {
     #[doc="A decoder for EUC-JP with JIS X 0212 in G3."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct EUCJP0212Decoder;
 
     module eucjp;
@@ -417,7 +417,7 @@ mod eucjp_tests {
  * It requires some cares to handle
  * since the second byte of JIS X 0208 can have its MSB unset.
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Windows31JEncoding;
 
 impl Encoding for Windows31JEncoding {
@@ -428,7 +428,7 @@ impl Encoding for Windows31JEncoding {
 }
 
 /// An encoder for Shift_JIS with IBM/NEC extensions.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Windows31JEncoder;
 
 impl Windows31JEncoder {
@@ -476,7 +476,7 @@ impl RawEncoder for Windows31JEncoder {
 
 ascii_compatible_stateful_decoder! {
     #[doc="A decoder for Shift_JIS with IBM/NEC extensions."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct Windows31JDecoder;
 
     module windows31j;
@@ -711,7 +711,7 @@ mod windows31j_tests {
  *   but willfully violated)
  * - JIS X 0212-1990 (`ESC $ ( D`, XXX asymmetric support)
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ISO2022JPEncoding;
 
 impl Encoding for ISO2022JPEncoding {
@@ -721,7 +721,7 @@ impl Encoding for ISO2022JPEncoding {
     fn raw_decoder(&self) -> Box<RawDecoder> { ISO2022JPDecoder::new() }
 }
 
-#[deriving(PartialEq,Clone,Copy)]
+#[derive(PartialEq,Clone,Copy)]
 enum ISO2022JPState {
     ASCII, // U+0000..007F, U+00A5, U+203E
     Katakana, // JIS X 0201: U+FF61..FF9F
@@ -729,7 +729,7 @@ enum ISO2022JPState {
 }
 
 /// An encoder for ISO-2022-JP without JIS X 0212/0213 support.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct ISO2022JPEncoder {
     st: ISO2022JPState
 }
@@ -794,7 +794,7 @@ impl RawEncoder for ISO2022JPEncoder {
 
 stateful_decoder! {
     #[doc="A decoder for ISO-2022-JP with JIS X 0212 support."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct ISO2022JPDecoder;
 
     module iso2022jp;

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -4,6 +4,7 @@
 
 //! Legacy Korean encodings based on KS X 1001.
 
+use std::borrow::IntoCow;
 use util::StrCharIndex;
 use index_korean as index;
 use types::*;

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -20,7 +20,7 @@ use types::*;
  * Its design strongly resembles that of Shift_JIS but less prone to errors
  * since the set of MSB-unset second bytes is much limited compared to Shift_JIS.
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Windows949Encoding;
 
 impl Encoding for Windows949Encoding {
@@ -31,7 +31,7 @@ impl Encoding for Windows949Encoding {
 }
 
 /// An encoder for Windows code page 949.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Windows949Encoder;
 
 impl Windows949Encoder {
@@ -70,7 +70,7 @@ impl RawEncoder for Windows949Encoder {
 
 ascii_compatible_stateful_decoder! {
     #[doc="A decoder for Windows code page 949."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct Windows949Decoder;
 
     module windows949;

--- a/src/codec/simpchinese.rs
+++ b/src/codec/simpchinese.rs
@@ -32,7 +32,7 @@ use types::*;
  * - Finally, GB 18030 added four-byte sequences to GBK for becoming a pan-Unicode encoding,
  *   while adding new characters to the (former) GBK region again.
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct GB18030Encoding;
 
 impl Encoding for GB18030Encoding {
@@ -43,7 +43,7 @@ impl Encoding for GB18030Encoding {
 }
 
 /// An encoder for GB 18030.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct GB18030Encoder;
 
 impl GB18030Encoder {
@@ -91,7 +91,7 @@ impl RawEncoder for GB18030Encoder {
 
 ascii_compatible_stateful_decoder! {
     #[doc="A decoder for GB 18030."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct GB18030Decoder;
 
     module gb18030;
@@ -330,7 +330,7 @@ mod gb18030_tests {
  * they are equivalent to ISO-2022-CN escape sequences `ESC $ ) A` and `ESC ( B`.
  * Additional escape sequences `~~` (for a literal `~`) and `~\n` (ignored) are also supported.
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct HZEncoding;
 
 impl Encoding for HZEncoding {
@@ -341,7 +341,7 @@ impl Encoding for HZEncoding {
 }
 
 /// An encoder for HZ.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct HZEncoder {
     escaped: bool,
 }
@@ -405,7 +405,7 @@ impl RawEncoder for HZEncoder {
 
 stateful_decoder! {
     #[doc="A decoder for HZ."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct HZDecoder;
 
     module hz;

--- a/src/codec/simpchinese.rs
+++ b/src/codec/simpchinese.rs
@@ -4,6 +4,7 @@
 
 //! Legacy simplified Chinese encodings based on GB 2312 and GB 18030.
 
+use std::borrow::IntoCow;
 use util::StrCharIndex;
 use index_simpchinese as index;
 use types::*;

--- a/src/codec/singlebyte.rs
+++ b/src/codec/singlebyte.rs
@@ -9,7 +9,7 @@ use util::{as_char, StrCharIndex};
 use types::*;
 
 /// A common framework for single-byte encodings based on ASCII.
-#[deriving(Copy)]
+#[derive(Copy)]
 pub struct SingleByteEncoding {
     pub name: &'static str,
     pub whatwg_name: Option<&'static str>,
@@ -25,7 +25,7 @@ impl Encoding for SingleByteEncoding {
 }
 
 /// An encoder for single-byte encodings based on ASCII.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct SingleByteEncoder {
     index_backward: extern "Rust" fn(u32) -> u8,
 }
@@ -67,7 +67,7 @@ impl RawEncoder for SingleByteEncoder {
 }
 
 /// A decoder for single-byte encodings based on ASCII.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct SingleByteDecoder {
     index_forward: extern "Rust" fn(u8) -> u16,
 }

--- a/src/codec/singlebyte.rs
+++ b/src/codec/singlebyte.rs
@@ -4,6 +4,7 @@
 
 //! Common codec implementation for single-byte encodings.
 
+use std::borrow::IntoCow;
 use util::{as_char, StrCharIndex};
 use types::*;
 

--- a/src/codec/tradchinese.rs
+++ b/src/codec/tradchinese.rs
@@ -4,6 +4,7 @@
 
 //! Legacy traditional Chinese encodings.
 
+use std::borrow::IntoCow;
 use util::StrCharIndex;
 use index_tradchinese as index;
 use types::*;

--- a/src/codec/tradchinese.rs
+++ b/src/codec/tradchinese.rs
@@ -23,7 +23,7 @@ use types::*;
  * This particular implementation of Big5 includes the widespread ETEN and HKSCS extensions,
  * but excludes less common extensions such as Big5+, Big-5E and Unicode-at-on.
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct BigFive2003Encoding;
 
 impl Encoding for BigFive2003Encoding {
@@ -34,7 +34,7 @@ impl Encoding for BigFive2003Encoding {
 }
 
 /// An encoder for Big5-2003.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct BigFive2003Encoder;
 
 impl BigFive2003Encoder {
@@ -76,7 +76,7 @@ impl RawEncoder for BigFive2003Encoder {
 
 ascii_compatible_stateful_decoder! {
     #[doc="A decoder for Big5-2003 with HKSCS-2008 extension."]
-    #[deriving(Clone, Copy)]
+    #[derive(Clone, Copy)]
     struct BigFive2003HKSCS2008Decoder;
 
     module bigfive2003;

--- a/src/codec/utf_16.rs
+++ b/src/codec/utf_16.rs
@@ -4,6 +4,7 @@
 
 //! UTF-16.
 
+use std::borrow::IntoCow;
 use util::{as_char, StrCharIndex};
 use types::*;
 

--- a/src/codec/utf_16.rs
+++ b/src/codec/utf_16.rs
@@ -11,13 +11,13 @@ use types::*;
 /// An implementation type for little endian.
 ///
 /// Can be used as a type parameter to `UTF16Encoding`, `UTF16Encoder` and `UTF16Decoder`.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Little;
 
 /// An implementation type for big endian.
 ///
 /// Can be used as a type parameter to `UTF16Encoding`, `UTF16Encoder` and `UTF16Decoder`.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct Big;
 
 /// An internal trait used to customize UTF-16 implementations.
@@ -69,7 +69,7 @@ impl Endian for Big {
  * This type is specialized with endianness type `E`,
  * which should be either `Little` (little endian) or `Big` (big endian).
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct UTF16Encoding<E>;
 
 /// UTF-16 in little endian.
@@ -92,7 +92,7 @@ impl<E:Endian+Clone+'static> Encoding for UTF16Encoding<E> {
  * This type is specialized with endianness type `E`,
  * which should be either `Little` (little endian) or `Big` (big endian).
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct UTF16Encoder<E>;
 
 impl<E:Endian+Clone+'static> UTF16Encoder<E> {

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -25,6 +25,7 @@
 //! UTF-8, the universal encoding.
 
 use std::{str, mem};
+use std::borrow::IntoCow;
 use types::*;
 
 /**

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -43,7 +43,7 @@ use types::*;
  * The UTF-8 scanner used by this module is heavily based on Bjoern Hoehrmann's
  * [Flexible and Economical UTF-8 Decoder](http://bjoern.hoehrmann.de/utf-8/decoder/dfa/).
  */
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct UTF8Encoding;
 
 impl Encoding for UTF8Encoding {
@@ -54,7 +54,7 @@ impl Encoding for UTF8Encoding {
 }
 
 /// An encoder for UTF-8.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct UTF8Encoder;
 
 impl UTF8Encoder {
@@ -78,7 +78,7 @@ impl RawEncoder for UTF8Encoder {
 }
 
 /// A decoder for UTF-8.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct UTF8Decoder {
     queuelen: uint,
     queue: [u8; 4],

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -80,17 +80,17 @@ impl RawEncoder for UTF8Encoder {
 #[deriving(Clone, Copy)]
 pub struct UTF8Decoder {
     queuelen: uint,
-    queue: [u8, ..4],
+    queue: [u8; 4],
     state: u8,
 }
 
 impl UTF8Decoder {
     pub fn new() -> Box<RawDecoder> {
-        box UTF8Decoder { queuelen: 0, queue: [0, ..4], state: INITIAL_STATE } as Box<RawDecoder>
+        box UTF8Decoder { queuelen: 0, queue: [0; 4], state: INITIAL_STATE } as Box<RawDecoder>
     }
 }
 
-static CHAR_CATEGORY: [u8, ..256] = [
+static CHAR_CATEGORY: [u8; 256] = [
     //  0 (00-7F): one byte sequence
     //  1 (80-8F): continuation byte
     //  2 (C2-DF): start of two byte sequence
@@ -114,7 +114,7 @@ static CHAR_CATEGORY: [u8, ..256] = [
     10,3,3,3,3,3,3,3,3,3,3,3,3,4,3,3, 11,6,6,6,5,8,8,8,8,8,8,8,8,8,8,8,
 ];
 
-static STATE_TRANSITIONS: [u8, ..110] = [
+static STATE_TRANSITIONS: [u8; 110] = [
      0,98,12,24,48,84,72,98,98,98,36,60,       //  0: '??
     86, 0,86,86,86,86,86, 0,86, 0,86,86,       // 12: .. 'cc
     86,12,86,86,86,86,86,12,86,12,86,86,       // 24: .. 'cc cc

--- a/src/codec/whatwg.rs
+++ b/src/codec/whatwg.rs
@@ -9,7 +9,7 @@ use types::*;
 
 /// Replacement encoding used to solve a particular attack vector due to mismatching server and
 /// client supports for encodings. It is rarely useful outside.
-#[deriving(Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct EncoderOnlyUTF8Encoding;
 
 impl Encoding for EncoderOnlyUTF8Encoding {

--- a/src/types.rs
+++ b/src/types.rs
@@ -364,7 +364,7 @@ pub type DecoderTrapFunc =
 
 /// Trap, which handles decoder errors.
 #[stable]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum DecoderTrap {
     /// Immediately fails on errors.
     /// Corresponds to WHATWG "fatal" error algorithm.
@@ -394,7 +394,7 @@ impl DecoderTrap {
 }
 
 #[stable]
-#[deriving(Copy)]
+#[derive(Copy)]
 pub enum EncoderTrap {
     /// Immediately fails on errors.
     /// Corresponds to WHATWG "fatal" error algorithm.

--- a/src/types.rs
+++ b/src/types.rs
@@ -471,6 +471,7 @@ mod tests {
     use super::*;
     use super::EncoderTrap::NcrEscape;
     use util::StrCharIndex;
+    use std::borrow::IntoCow;
 
     // a contrived encoding example: same as ASCII, but inserts `prepend` between each character
     // within two "e"s (so that `widespread` becomes `wide*s*p*r*ead` and `eeeeasel` becomes

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,6 +9,7 @@
 use std::{str, mem};
 use std::borrow::IntoCow;
 use std::default::Default;
+use std::num::ToPrimitive;
 use types;
 
 /// Unchecked conversion to `char`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -144,7 +144,7 @@ macro_rules! stateful_decoder(
         #[allow(non_snake_case)]
         mod $stmod {
             pub use self::State::*;
-            #[deriving(PartialEq,Clone,Copy)]
+            #[derive(PartialEq,Clone,Copy)]
             pub enum State {
                 $inist,
                 $(

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,7 @@
 #![macro_escape]
 
 use std::{str, mem};
+use std::borrow::IntoCow;
 use std::default::Default;
 use types;
 


### PR DESCRIPTION
rustc 0.13.0-nightly (c89417130 2015-01-02 21:56:13 +0000)

Looks like IntoCow and ToPrimitive left the prelude. The `[x, ..5]` syntax was removed, and `#[deriving(...)]` is now `#[derive(...)]` (last one was a deprecation warning, not an error).