### PR TITLE
Upgrade to rustc 0.13.0-nightly (c6c786671 2015-01-04 00:50:59 +0000)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,7 +172,7 @@ Whenever in doubt, look at the source code and specifications for detailed expla
 
 */
 
-#![feature(globs, macro_rules, slicing_syntax)]
+#![feature(globs, macro_rules, slicing_syntax, associated_types)]
 
 #![allow(experimental)]
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,7 +23,9 @@ pub struct StrCharIndexIterator<'r> {
     string: &'r str,
 }
 
-impl<'r> Iterator<((uint,uint), char)> for StrCharIndexIterator<'r> {
+impl<'r> Iterator for StrCharIndexIterator<'r> {
+    type Item = ((uint,uint), char);
+
     #[inline]
     fn next(&mut self) -> Option<((uint,uint), char)> {
         if self.index < self.string.len() {


### PR DESCRIPTION
`Iterator` uses associated types now.