### PR TITLE
Move all the `cargo test ...` commands from `.travis.yml` to a Makefile,...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,7 @@ env:
     - secure: WtFY+Nu8Erb9JOqX38XHyMH0C4b0y5sDAVw2GSo3pr9o5Re/is8Fa7CBtikoZp1IfB70b7mNK7T5hqvh289M+Ur43OA4EAjWi9rKZYAoK94GXRMNCwhUQR4OiPkQ8s/oJxcNGgb2lKT4Bwtpa2/kT4HA2Md6wo1Db30D4lskrsc=
 script:
   - cargo build -v
-  - cargo test -v
-  - cargo test -v -p encoding-index-singlebyte
-  - cargo test -v -p encoding-index-korean
-  - cargo test -v -p encoding-index-japanese
-  - cargo test -v -p encoding-index-simpchinese
-  - cargo test -v -p encoding-index-tradchinese
+  - make test
   - cargo doc
 after_script:
   - cd target && curl http://www.rust-ci.org/artifacts/put?t=$RUSTCI_TOKEN | sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test
+test:
+	cargo test -v
+	cargo test -v -p encoding-index-singlebyte
+	cargo test -v -p encoding-index-korean
+	cargo test -v -p encoding-index-japanese
+	cargo test -v -p encoding-index-simpchinese
+	cargo test -v -p encoding-index-tradchinese


### PR DESCRIPTION
... for local testing.

It could just as well be a shell script instead of a Makefile.

I don’t believe running `cargo build` on Travis is useful, (since `cargo test` does the same and more) but I left it since that is unrelated to this change.