### PR TITLE
Fix hyphens on target names error

### DIFF
--- a/src/index/japanese/Cargo.toml
+++ b/src/index/japanese/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../../README.md"
 license = "CC0-1.0"
 
 [lib]
-name = "encoding-index-japanese"
+name = "encoding_index_japanese"
 path = "lib.rs"
 
 [dependencies.encoding_index_tests]

--- a/src/index/korean/Cargo.toml
+++ b/src/index/korean/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../../README.md"
 license = "CC0-1.0"
 
 [lib]
-name = "encoding-index-korean"
+name = "encoding_index_korean"
 path = "lib.rs"
 
 [dependencies.encoding_index_tests]

--- a/src/index/korean/lib.rs
+++ b/src/index/korean/lib.rs
@@ -6,6 +6,7 @@
 //! Korean index tables for [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(core))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/index/simpchinese/Cargo.toml
+++ b/src/index/simpchinese/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../../README.md"
 license = "CC0-1.0"
 
 [lib]
-name = "encoding-index-simpchinese"
+name = "encoding_index_simpchinese"
 path = "lib.rs"
 
 [dependencies.encoding_index_tests]

--- a/src/index/simpchinese/lib.rs
+++ b/src/index/simpchinese/lib.rs
@@ -7,6 +7,7 @@
 //! [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(core))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/index/singlebyte/Cargo.toml
+++ b/src/index/singlebyte/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../../README.md"
 license = "CC0-1.0"
 
 [lib]
-name = "encoding-index-singlebyte"
+name = "encoding_index_singlebyte"
 path = "lib.rs"
 
 [dependencies.encoding_index_tests]

--- a/src/index/singlebyte/lib.rs
+++ b/src/index/singlebyte/lib.rs
@@ -7,6 +7,7 @@
 //! [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(core))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/index/tradchinese/Cargo.toml
+++ b/src/index/tradchinese/Cargo.toml
@@ -9,7 +9,7 @@ readme = "../../../README.md"
 license = "CC0-1.0"
 
 [lib]
-name = "encoding-index-tradchinese"
+name = "encoding_index_tradchinese"
 path = "lib.rs"
 
 [dependencies.encoding_index_tests]

--- a/src/index/tradchinese/lib.rs
+++ b/src/index/tradchinese/lib.rs
@@ -8,6 +8,7 @@
 
 #![feature(core)]
 #![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(core))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,14 +172,15 @@ Whenever in doubt, look at the source code and specifications for detailed expla
 
 */
 
+#![feature(into_cow)]
 #![feature(str_char)] // lib stability features as per RFC #507
 #![cfg_attr(test, feature(core, collections, test))] // ditto
 
-extern crate "encoding-index-singlebyte" as index_singlebyte;
-extern crate "encoding-index-korean" as index_korean;
-extern crate "encoding-index-japanese" as index_japanese;
-extern crate "encoding-index-simpchinese" as index_simpchinese;
-extern crate "encoding-index-tradchinese" as index_tradchinese;
+extern crate encoding_index_singlebyte as index_singlebyte;
+extern crate encoding_index_korean as index_korean;
+extern crate encoding_index_japanese as index_japanese;
+extern crate encoding_index_simpchinese as index_simpchinese;
+extern crate encoding_index_tradchinese as index_tradchinese;
 
 #[cfg(test)] extern crate test;
 


### PR DESCRIPTION
As of the latest nightly, the rules in https://github.com/rust-lang/rfcs/blob/master/text/0940-hyphens-considered-harmful.md are now fully implemented and in use. This patch fixes the errors on `cargo build` that arise when attempting to build projects that depend on this library:

```
Unable to get packages from source

Caused by:
  failed to parse manifest at `/home/filipe/.cargo/registry/src/github.com-1ecc6299db9ec823/encoding-index-simpchinese-1.20141219.1/Cargo.toml`

Caused by:
  target names cannot contain hyphens: encoding-index-simpchinese
```