### PR TITLE
Remove usage of unstable features outside tests

### DIFF
--- a/examples/recode.rs
+++ b/examples/recode.rs
@@ -2,9 +2,6 @@
 // Copyright (c) 2014-2015, Kang Seonghoon.
 // See README.md and LICENSE.txt for details.
 
-#![feature(core, collections)] // lib stability features as per RFC #507
-
-extern crate core;
 extern crate encoding;
 extern crate getopts;
 
@@ -28,7 +25,7 @@ fn main() {
     opts.optopt("o", "output", "output file", "FILE");
     opts.optflag("h", "help", "print this help menu");
 
-    let matches = match opts.parse(args.tail()) {
+    let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(e) => panic!(e.to_string()),
     };

--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -4,7 +4,7 @@
 
 //! 7-bit ASCII encoding.
 
-use std::{str, mem};
+use std::mem;
 use std::convert::Into;
 use types::*;
 
@@ -41,9 +41,9 @@ impl RawEncoder for ASCIIEncoder {
         match input.as_bytes().iter().position(|&ch| ch >= 0x80) {
             Some(first_error) => {
                 output.write_bytes(&input.as_bytes()[..first_error]);
-                let str::CharRange {ch: _, next} = input.char_range_at(first_error);
+                let len = input[first_error..].chars().next().unwrap().len_utf8();
                 (first_error, Some(CodecError {
-                    upto: next as isize, cause: "unrepresentable character".into()
+                    upto: (first_error + len) as isize, cause: "unrepresentable character".into()
                 }))
             }
             None => {

--- a/src/codec/ascii.rs
+++ b/src/codec/ascii.rs
@@ -5,7 +5,7 @@
 //! 7-bit ASCII encoding.
 
 use std::{str, mem};
-use std::borrow::IntoCow;
+use std::convert::Into;
 use types::*;
 
 /**
@@ -43,7 +43,7 @@ impl RawEncoder for ASCIIEncoder {
                 output.write_bytes(&input.as_bytes()[..first_error]);
                 let str::CharRange {ch: _, next} = input.char_range_at(first_error);
                 (first_error, Some(CodecError {
-                    upto: next as isize, cause: "unrepresentable character".into_cow()
+                    upto: next as isize, cause: "unrepresentable character".into()
                 }))
             }
             None => {
@@ -81,7 +81,7 @@ impl RawDecoder for ASCIIDecoder {
             Some(first_error) => {
                 write_ascii_bytes(output, &input[..first_error]);
                 (first_error, Some(CodecError {
-                    upto: first_error as isize + 1, cause: "invalid sequence".into_cow()
+                    upto: first_error as isize + 1, cause: "invalid sequence".into()
                 }))
             }
             None => {

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -4,7 +4,6 @@
 
 //! A placeholder encoding that returns encoder/decoder error for every case.
 
-use std::str;
 use std::convert::Into;
 use types::*;
 
@@ -30,9 +29,8 @@ impl RawEncoder for ErrorEncoder {
     fn from_self(&self) -> Box<RawEncoder> { ErrorEncoder::new() }
 
     fn raw_feed(&mut self, input: &str, _output: &mut ByteWriter) -> (usize, Option<CodecError>) {
-        if input.len() > 0 {
-            let str::CharRange {ch: _, next} = input.char_range_at(0);
-            (0, Some(CodecError { upto: next as isize,
+        if let Some(ch) = input.chars().next() {
+            (0, Some(CodecError { upto: ch.len_utf8() as isize,
                                   cause: "unrepresentable character".into() }))
         } else {
             (0, None)

--- a/src/codec/error.rs
+++ b/src/codec/error.rs
@@ -5,7 +5,7 @@
 //! A placeholder encoding that returns encoder/decoder error for every case.
 
 use std::str;
-use std::borrow::IntoCow;
+use std::convert::Into;
 use types::*;
 
 /// An encoding that returns encoder/decoder error for every case.
@@ -33,7 +33,7 @@ impl RawEncoder for ErrorEncoder {
         if input.len() > 0 {
             let str::CharRange {ch: _, next} = input.char_range_at(0);
             (0, Some(CodecError { upto: next as isize,
-                                  cause: "unrepresentable character".into_cow() }))
+                                  cause: "unrepresentable character".into() }))
         } else {
             (0, None)
         }
@@ -58,7 +58,7 @@ impl RawDecoder for ErrorDecoder {
     fn raw_feed(&mut self,
                 input: &[u8], _output: &mut StringWriter) -> (usize, Option<CodecError>) {
         if input.len() > 0 {
-            (0, Some(CodecError { upto: 1, cause: "invalid sequence".into_cow() }))
+            (0, Some(CodecError { upto: 1, cause: "invalid sequence".into() }))
         } else {
             (0, None)
         }

--- a/src/codec/japanese.rs
+++ b/src/codec/japanese.rs
@@ -4,7 +4,7 @@
 
 //! Legacy Japanese encodings based on JIS X 0208 and JIS X 0212.
 
-use std::borrow::IntoCow;
+use std::convert::Into;
 use util::StrCharIndex;
 use index_japanese as index;
 use types::*;
@@ -63,7 +63,7 @@ impl RawEncoder for EUCJPEncoder {
                     let ptr = index::jis0208::backward(ch as u32);
                     if ptr == 0xffff {
                         return (i, Some(CodecError {
-                            upto: j as isize, cause: "unrepresentable character".into_cow()
+                            upto: j as isize, cause: "unrepresentable character".into()
                         }));
                     } else {
                         let lead = ptr / 94 + 0xa1;
@@ -457,7 +457,7 @@ impl RawEncoder for Windows31JEncoder {
                     let ptr = index::jis0208::backward_remapped(ch as u32);
                     if ptr == 0xffff {
                         return (i, Some(CodecError {
-                            upto: j as isize, cause: "unrepresentable character".into_cow(),
+                            upto: j as isize, cause: "unrepresentable character".into(),
                         }));
                     } else {
                         let lead = ptr / 188;
@@ -776,7 +776,7 @@ impl RawEncoder for ISO2022JPEncoder {
                     if ptr == 0xffff {
                         self.st = st; // do NOT reset the state!
                         return (i, Some(CodecError {
-                            upto: j as isize, cause: "unrepresentable character".into_cow()
+                            upto: j as isize, cause: "unrepresentable character".into()
                         }));
                     } else {
                         ensure_Lead!();

--- a/src/codec/korean.rs
+++ b/src/codec/korean.rs
@@ -4,7 +4,7 @@
 
 //! Legacy Korean encodings based on KS X 1001.
 
-use std::borrow::IntoCow;
+use std::convert::Into;
 use util::StrCharIndex;
 use index_korean as index;
 use types::*;
@@ -52,7 +52,7 @@ impl RawEncoder for Windows949Encoder {
                 let ptr = index::euc_kr::backward(ch as u32);
                 if ptr == 0xffff {
                     return (i, Some(CodecError {
-                        upto: j as isize, cause: "unrepresentable character".into_cow()
+                        upto: j as isize, cause: "unrepresentable character".into()
                     }));
                 } else {
                     output.write_byte((ptr / 190 + 0x81) as u8);

--- a/src/codec/simpchinese.rs
+++ b/src/codec/simpchinese.rs
@@ -4,7 +4,7 @@
 
 //! Legacy simplified Chinese encodings based on GB 2312 and GB 18030.
 
-use std::borrow::IntoCow;
+use std::convert::Into;
 use util::StrCharIndex;
 use index_simpchinese as index;
 use types::*;
@@ -377,7 +377,7 @@ impl RawEncoder for HZEncoder {
                 if ptr == 0xffff {
                     self.escaped = escaped; // do NOT reset the state!
                     return (i, Some(CodecError {
-                        upto: j as isize, cause: "unrepresentable character".into_cow()
+                        upto: j as isize, cause: "unrepresentable character".into()
                     }));
                 } else {
                     let lead = ptr / 190;
@@ -385,7 +385,7 @@ impl RawEncoder for HZEncoder {
                     if lead < 0x21 - 1 || trail < 0x21 + 0x3f { // GBK extension, ignored
                         self.escaped = escaped; // do NOT reset the state!
                         return (i, Some(CodecError {
-                            upto: j as isize, cause: "unrepresentable character".into_cow()
+                            upto: j as isize, cause: "unrepresentable character".into()
                         }));
                     } else {
                         ensure_escaped!();

--- a/src/codec/singlebyte.rs
+++ b/src/codec/singlebyte.rs
@@ -4,7 +4,7 @@
 
 //! Common codec implementation for single-byte encodings.
 
-use std::borrow::IntoCow;
+use std::convert::Into;
 use util::{as_char, StrCharIndex};
 use types::*;
 
@@ -53,7 +53,7 @@ impl RawEncoder for SingleByteEncoder {
                     output.write_byte(index);
                 } else {
                     return (i, Some(CodecError {
-                        upto: j as isize, cause: "unrepresentable character".into_cow()
+                        upto: j as isize, cause: "unrepresentable character".into()
                     }));
                 }
             }
@@ -96,7 +96,7 @@ impl RawDecoder for SingleByteDecoder {
                     output.write_char(as_char(ch as u32));
                 } else {
                     return (i, Some(CodecError {
-                        upto: i as isize + 1, cause: "invalid sequence".into_cow()
+                        upto: i as isize + 1, cause: "invalid sequence".into()
                     }));
                 }
             }

--- a/src/codec/tradchinese.rs
+++ b/src/codec/tradchinese.rs
@@ -4,7 +4,7 @@
 
 //! Legacy traditional Chinese encodings.
 
-use std::borrow::IntoCow;
+use std::convert::Into;
 use util::StrCharIndex;
 use index_tradchinese as index;
 use types::*;
@@ -56,7 +56,7 @@ impl RawEncoder for BigFive2003Encoder {
                 if ptr == 0xffff || ptr < (0xa1 - 0x81) * 157 {
                     // no HKSCS extension (XXX doesn't HKSCS include 0xFA40..0xFEFE?)
                     return (i, Some(CodecError {
-                        upto: j as isize, cause: "unrepresentable character".into_cow()
+                        upto: j as isize, cause: "unrepresentable character".into()
                     }));
                 }
                 let lead = ptr / 157 + 0x81;

--- a/src/codec/utf_16.rs
+++ b/src/codec/utf_16.rs
@@ -4,7 +4,7 @@
 
 //! UTF-16.
 
-use std::borrow::IntoCow;
+use std::convert::Into;
 use std::marker::PhantomData;
 use util::as_char;
 use types::*;
@@ -193,7 +193,7 @@ impl<E: Endian> RawDecoder for UTF16Decoder<E> {
                     }
                     _ => {
                         return (processed, Some(CodecError {
-                            upto: i as isize - 2, cause: "invalid sequence".into_cow()
+                            upto: i as isize - 2, cause: "invalid sequence".into()
                         }));
                     }
                 }
@@ -205,7 +205,7 @@ impl<E: Endian> RawDecoder for UTF16Decoder<E> {
                     }
                     0xdc00...0xdfff => {
                         return (processed, Some(CodecError {
-                            upto: i as isize, cause: "invalid sequence".into_cow()
+                            upto: i as isize, cause: "invalid sequence".into()
                         }));
                     }
                     _ => {
@@ -235,7 +235,7 @@ impl<E: Endian> RawDecoder for UTF16Decoder<E> {
                     self.leadbyte = 0xffff;
                     self.leadsurrogate = 0xffff;
                     return (processed, Some(CodecError {
-                        upto: i as isize - 2, cause: "invalid sequence".into_cow()
+                        upto: i as isize - 2, cause: "invalid sequence".into()
                     }));
                 }
             }
@@ -267,14 +267,14 @@ impl<E: Endian> RawDecoder for UTF16Decoder<E> {
                         }
                         _ => {
                             return (processed, Some(CodecError {
-                                upto: i as isize - 1, cause: "invalid sequence".into_cow()
+                                upto: i as isize - 1, cause: "invalid sequence".into()
                             }));
                         }
                     }
                 }
                 0xdc00...0xdfff => {
                     return (processed, Some(CodecError {
-                        upto: i as isize + 1, cause: "invalid sequence".into_cow()
+                        upto: i as isize + 1, cause: "invalid sequence".into()
                     }));
                 }
                 _ => {
@@ -293,7 +293,7 @@ impl<E: Endian> RawDecoder for UTF16Decoder<E> {
         self.leadbyte = 0xffff;
         self.leadsurrogate = 0xffff;
         if leadbyte != 0xffff || leadsurrogate != 0xffff {
-            Some(CodecError { upto: 0, cause: "incomplete sequence".into_cow() })
+            Some(CodecError { upto: 0, cause: "incomplete sequence".into() })
         } else {
             None
         }

--- a/src/codec/utf_8.rs
+++ b/src/codec/utf_8.rs
@@ -25,7 +25,7 @@
 //! UTF-8, the universal encoding.
 
 use std::{str, mem};
-use std::borrow::IntoCow;
+use std::convert::Into;
 use types::*;
 
 /**
@@ -173,7 +173,7 @@ impl RawDecoder for UTF8Decoder {
                 self.queuelen = 0;
                 write_bytes(output, &input[0..processed]);
                 return (processed, Some(CodecError {
-                    upto: upto as isize, cause: "invalid sequence".into_cow()
+                    upto: upto as isize, cause: "invalid sequence".into()
                 }));
             }
         }
@@ -200,7 +200,7 @@ impl RawDecoder for UTF8Decoder {
         self.state = INITIAL_STATE;
         self.queuelen = 0;
         if state != ACCEPT_STATE {
-            Some(CodecError { upto: 0, cause: "incomplete sequence".into_cow() })
+            Some(CodecError { upto: 0, cause: "incomplete sequence".into() })
         } else {
             assert!(queuelen == 0);
             None

--- a/src/index/japanese/lib.rs
+++ b/src/index/japanese/lib.rs
@@ -5,8 +5,7 @@
 
 //! Japanese index tables for [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(core)]
-#![cfg_attr(test, feature(test))]
+#![cfg_attr(test, feature(core, test))]
 
 #[cfg(test)]
 #[macro_use]

--- a/src/index/tradchinese/lib.rs
+++ b/src/index/tradchinese/lib.rs
@@ -6,7 +6,6 @@
 //! Traditional Chinese index tables for
 //! [rust-encoding](https://github.com/lifthrasiir/rust-encoding).
 
-#![feature(core)]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(test, feature(core))]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,8 +173,7 @@ Whenever in doubt, look at the source code and specifications for detailed expla
 */
 
 #![feature(convert)]
-//#![feature(str_char)] // lib stability features as per RFC #507
-#![cfg_attr(test, feature(core, collections, test))] // ditto
+#![cfg_attr(test, feature(core, collections, test))] // lib stability features as per RFC #507
 
 extern crate encoding_index_singlebyte as index_singlebyte;
 extern crate encoding_index_korean as index_korean;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,8 +172,8 @@ Whenever in doubt, look at the source code and specifications for detailed expla
 
 */
 
-#![feature(into_cow)]
-#![feature(str_char)] // lib stability features as per RFC #507
+#![feature(convert)]
+//#![feature(str_char)] // lib stability features as per RFC #507
 #![cfg_attr(test, feature(core, collections, test))] // ditto
 
 extern crate encoding_index_singlebyte as index_singlebyte;

--- a/src/types.rs
+++ b/src/types.rs
@@ -471,7 +471,7 @@ mod tests {
     use super::*;
     use super::EncoderTrap::NcrEscape;
     use util::StrCharIndex;
-    use std::borrow::IntoCow;
+    use std::convert::Into;
 
     // a contrived encoding example: same as ASCII, but inserts `prepend` between each character
     // within two "e"s (so that `widespread` becomes `wide*s*p*r*ead` and `eeeeasel` becomes
@@ -498,7 +498,7 @@ mod tests {
                     }
                 } else {
                     return (i, Some(CodecError { upto: j as isize,
-                                                 cause: "!!!".into_cow() }));
+                                                 cause: "!!!".into() }));
                 }
             }
             (input.len(), None)

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,7 @@ pub fn as_char(ch: u32) -> char {
 /// External iterator for a string's characters with its corresponding byte offset range.
 pub struct StrCharIndexIterator<'r> {
     index: usize,
-    string: &'r str,
+    chars: str::Chars<'r>,
 }
 
 impl<'r> Iterator for StrCharIndexIterator<'r> {
@@ -27,9 +27,9 @@ impl<'r> Iterator for StrCharIndexIterator<'r> {
 
     #[inline]
     fn next(&mut self) -> Option<((usize,usize), char)> {
-        if self.index < self.string.len() {
-            let str::CharRange {ch, next} = self.string.char_range_at(self.index);
+        if let Some(ch) = self.chars.next() {
             let prev = self.index;
+            let next = prev + ch.len_utf8();
             self.index = next;
             Some(((prev, next), ch))
         } else {
@@ -46,7 +46,7 @@ pub trait StrCharIndex<'r> {
 impl<'r> StrCharIndex<'r> for &'r str {
     /// Iterates over each character with corresponding byte offset range.
     fn index_iter(&self) -> StrCharIndexIterator<'r> {
-        StrCharIndexIterator { index: 0, string: *self }
+        StrCharIndexIterator { index: 0, chars: self.chars() }
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@
 
 use std::{str, char, mem};
 use std::marker::PhantomData;
-use std::borrow::IntoCow;
+use std::convert::Into;
 use std::default::Default;
 use types;
 
@@ -109,7 +109,7 @@ impl<'a, St: Default> StatefulDecoderHelper<'a, St> {
     /// If this is the last expr in the rules, also resets back to the initial state.
     #[inline(always)]
     pub fn err(&mut self, msg: &'static str) -> St {
-        self.err = Some(types::CodecError { upto: self.pos as isize, cause: msg.into_cow() });
+        self.err = Some(types::CodecError { upto: self.pos as isize, cause: msg.into() });
         Default::default()
     }
 
@@ -121,7 +121,7 @@ impl<'a, St: Default> StatefulDecoderHelper<'a, St> {
     #[inline(always)]
     pub fn backup_and_err(&mut self, backup: usize, msg: &'static str) -> St {
         let upto = self.pos as isize - backup as isize;
-        self.err = Some(types::CodecError { upto: upto, cause: msg.into_cow() });
+        self.err = Some(types::CodecError { upto: upto, cause: msg.into() });
         Default::default()
     }
 }


### PR DESCRIPTION
… except for conversion traits, which should be stable in the next Nightly.

This makes the library usable in Rust’s beta/stable channels.