### PR TITLE
Separate GBK and GB 18030 encodings, fix GBK encoding.

### DIFF
--- a/src/all.rs
+++ b/src/all.rs
@@ -74,7 +74,8 @@ unique!(#[stable] var=WINDOWS_949, mod=codec::korean, val=Windows949Encoding);
 unique!(#[unstable] var=EUC_JP, mod=codec::japanese, val=EUCJPEncoding);
 unique!(#[unstable] var=WINDOWS_31J, mod=codec::japanese, val=Windows31JEncoding);
 unique!(#[unstable] var=ISO_2022_JP, mod=codec::japanese, val=ISO2022JPEncoding);
-unique!(#[stable] var=GB18030, mod=codec::simpchinese, val=GB18030Encoding);
+unique!(#[stable] var=GBK, mod=codec::simpchinese, ty=GBKEncoding, val=GBK_ENCODING);
+unique!(#[stable] var=GB18030, mod=codec::simpchinese, ty=GB18030Encoding, val=GB18030_ENCODING);
 unique!(#[unstable] var=HZ, mod=codec::simpchinese, val=HZEncoding);
 unique!(#[unstable] var=BIG5_2003, mod=codec::tradchinese, val=BigFive2003Encoding);
 

--- a/src/label.rs
+++ b/src/label.rs
@@ -217,13 +217,14 @@ pub fn encoding_from_whatwg_label(label: &str) -> Option<EncodingRef> {
         "chinese" |
         "csgb2312" |
         "csiso58gb231280" |
-        "gb18030" |
         "gb2312" |
         "gb_2312" |
         "gb_2312-80" |
         "gbk" |
         "iso-ir-58" |
         "x-gbk" =>
+            Some(all::GBK as EncodingRef),
+        "gb18030" =>
             Some(all::GB18030 as EncodingRef),
         "hz-gb-2312" =>
             Some(all::HZ as EncodingRef),


### PR DESCRIPTION
Per the WHATWG spec, GBK and GB 18030 are separate encodings with separate sets of labels.
They share a common decoder, which is reused for both.
The encoder is extended to behave properly for the gbk encoding, when the gbk flag is set.

Also, I haven't written any tests yet because I wasn't exactly sure what to do; I'd appreciate some pointers on that before this gets merged.