### PR TITLE
Change hyphen to _

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ version = "~1.20141219.5"
 path = "src/index/korean"
 
 [dependencies.encoding-index-japanese]
-name = "encoding_index_korean"
+name = "encoding_index_japanese"
 version = "~1.20141219.5"
 path = "src/index/japanese"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,22 @@ version = "~1.20141219.5"
 path = "src/index/singlebyte"
 
 [dependencies.encoding-index-korean]
+name = "encoding_index_korean"
 version = "~1.20141219.5"
 path = "src/index/korean"
 
 [dependencies.encoding-index-japanese]
+name = "encoding_index_korean"
 version = "~1.20141219.5"
 path = "src/index/japanese"
 
 [dependencies.encoding-index-simpchinese]
+name = "encoding_index_simpchinese"
 version = "~1.20141219.5"
 path = "src/index/simpchinese"
 
 [dependencies.encoding-index-tradchinese]
+name = "encoding_index_tradchinese"
 version = "~1.20141219.5"
 path = "src/index/tradchinese"
 


### PR DESCRIPTION
I'm getting errors when building crates which depend on "encoding-index-*" crates because of the hyphen.

> cargo build
>Unable to get packages from source
>
>Caused by:
> failed to parse manifest at `.../.cargo/registry/src/github.com-1ecc6299db9ec823/encoding-index-tradchinese-1.20141219.2/Cargo.toml`
>
> Caused by:
> library target names cannot contain hyphens: encoding-index-tradchinese