### PR TITLE
Upgrade to rustc 1.0.0-nightly (2baf34825 2015-04-21) (built 2015-04-22)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,7 +234,6 @@ pub use self::types::{CodecError, ByteWriter, StringWriter,
 pub mod types;
 
 /// Codec implementations.
-#[unstable]
 pub mod codec {
     pub mod error;
     pub mod ascii;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,10 +228,6 @@ pub use self::types::{CodecError, ByteWriter, StringWriter,
                       EncoderTrapFunc, DecoderTrapFunc, DecoderTrap,
                       EncoderTrap, decode}; // reexport
 
-// XXX gah rust-lang/rust#15702
-#[deprecated = "use encoding::RawEncoder instead"] pub use self::types::RawEncoder as Encoder;
-#[deprecated = "use encoding::RawDecoder instead"] pub use self::types::RawDecoder as Decoder;
-
 #[macro_use] mod util;
 #[cfg(test)] #[macro_use] mod testutils;
 


### PR DESCRIPTION
Note: this **removes** the deprecated `Encoder` and `Decoder` re-exports.