### PR TITLE
Implement fmt::Debug for Encoding

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -59,6 +59,17 @@ mod tests {
     }
 
     #[test]
+    fn test_encoding_debug_format() {
+        let enc = MyEncoding {
+            flag: true,
+            prohibit: '\u{80}',
+            prepend: "",
+        };
+
+        assert_eq!(format!("{:?}", &enc as &Encoding), "Encoding(my encoding)");
+    }
+
+    #[test]
     fn test_reencoding_trap_with_ascii_compatible_encoding() {
         static COMPAT: &'static MyEncoding =
             &MyEncoding { flag: true, prohibit: '\u{80}', prepend: "" };

--- a/src/types/lib.rs
+++ b/src/types/lib.rs
@@ -53,6 +53,7 @@
  */
 
 use std::borrow::Cow;
+use std::fmt;
 
 /// Error information from either encoder or decoder.
 pub struct CodecError {
@@ -289,6 +290,15 @@ pub trait Encoding {
                 }
             }
         }
+    }
+}
+
+impl<'a> fmt::Debug for &'a Encoding {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        try!(fmt.write_str("Encoding("));
+        try!(fmt.write_str(self.name()));
+        try!(fmt.write_str(")"));
+        Ok(())
     }
 }
 


### PR DESCRIPTION
(note: scratching my own itch)

Implemented `fmt::Debug` trait for `Encoding`, as it not being implemented prevented from deriving `Debug` for any type that contains `Encoding` or `EncodingRef`.