### PR TITLE
Use Vec.extend_from_slice() for ByteWriter.write_bytes().

### DIFF
--- a/src/types/lib.rs
+++ b/src/types/lib.rs
@@ -95,7 +95,7 @@ impl ByteWriter for Vec<u8> {
     }
 
     fn write_bytes(&mut self, v: &[u8]) {
-        self.extend(v.iter().cloned());
+        self.extend_from_slice(v);
     }
 }
 


### PR DESCRIPTION
Makes the code paths that call this method faster.

(Dual-licensed under MIT / Apache 2.0 so does not complicate issue 93.)