### PR TITLE
Stop adding the old length to expected when reserving String space.

### DIFF
--- a/src/types/lib.rs
+++ b/src/types/lib.rs
@@ -118,8 +118,7 @@ pub trait StringWriter {
 
 impl StringWriter for String {
     fn writer_hint(&mut self, expectedlen: usize) {
-        let newlen = self.len() + expectedlen;
-        self.reserve(newlen);
+        self.reserve(expectedlen);
     }
 
     fn write_char(&mut self, c: char) {


### PR DESCRIPTION
The String::reserve() method takes the number of [additional](https://doc.rust-lang.org/std/string/struct.String.html#method.reserve) bytes not
including the bytes that the string already holds.