### PR TITLE
Provide access to the underlying container of writers in the common case

### DIFF
--- a/src/types/lib.rs
+++ b/src/types/lib.rs
@@ -83,6 +83,12 @@ pub trait ByteWriter {
 
     /// Writes a number of bytes.
     fn write_bytes(&mut self, v: &[u8]);
+
+    /// If this `ByteWriter` is a `Vec<u8>`, returns a mutable reference to
+    /// `self` as `Some(&mut Vec<u8>)`. Returns `None` otherwise.
+    fn as_mut_vec(&mut self) -> Option<&mut Vec<u8>> {
+        None
+    }
 }
 
 impl ByteWriter for Vec<u8> {
@@ -96,6 +102,10 @@ impl ByteWriter for Vec<u8> {
 
     fn write_bytes(&mut self, v: &[u8]) {
         self.extend_from_slice(v);
+    }
+
+    fn as_mut_vec(&mut self) -> Option<&mut Vec<u8>> {
+        Some(self)
     }
 }
 
@@ -114,6 +124,12 @@ pub trait StringWriter {
 
     /// Writes a string.
     fn write_str(&mut self, s: &str);
+
+    /// If this `StringWriter` is a `String`, returns a mutable reference to
+    /// `self` as `Some(&mut String)`. Returns `None` otherwise.
+    fn as_mut_string(&mut self) -> Option<&mut String> {
+        None
+    }
 }
 
 impl StringWriter for String {
@@ -127,6 +143,10 @@ impl StringWriter for String {
 
     fn write_str(&mut self, s: &str) {
         self.push_str(s);
+    }
+
+    fn as_mut_string(&mut self) -> Option<&mut String> {
+        Some(self)
     }
 }
 


### PR DESCRIPTION
(As discussed on IRC many weeks ago.)

When `StringWriter` is a `String`, provide access to the `String`.
When `ByteWriter` is a `Vec<u8>`, provide access to the `Vec<u8>`.

This allows converters that write directly to a slice without virtual method calls inside the conversion loop to work without an intermediate copy in the common case (i.e. with the default trait implementations) while not breaking compatibility with custom implementations of the traits. (And by giving access to the whole container object rather than just a slice, this allow the converter to tell the container to grow appropriately.)