### PR TITLE
Fix syntax highlighting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ custom table generation.
 
 To encode a string:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, EncoderTrap};
 use encoding::all::ISO_8859_1;
 
 assert_eq!(ISO_8859_1.encode("caf\u{e9}", EncoderTrap::Strict),
            Ok(vec![99,97,102,233]));
-~~~~
+```
 
 To encode a string with unrepresentable characters:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, EncoderTrap};
 use encoding::all::ISO_8859_2;
 
@@ -73,21 +73,21 @@ assert_eq!(ISO_8859_2.encode("Acme\u{a9}", EncoderTrap::Ignore),
            Ok(vec![65,99,109,101]));
 assert_eq!(ISO_8859_2.encode("Acme\u{a9}", EncoderTrap::NcrEscape),
            Ok(vec![65,99,109,101,38,35,49,54,57,59]));
-~~~~
+```
 
 To decode a byte sequence:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, DecoderTrap};
 use encoding::all::ISO_8859_1;
 
 assert_eq!(ISO_8859_1.decode(&[99,97,102,233], DecoderTrap::Strict),
            Ok("caf\u{e9}".to_string()));
-~~~~
+```
 
 To decode a byte sequence with invalid sequences:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, DecoderTrap};
 use encoding::all::ISO_8859_6;
 
@@ -96,11 +96,11 @@ assert_eq!(ISO_8859_6.decode(&[65,99,109,101,169], DecoderTrap::Replace),
            Ok("Acme\u{fffd}".to_string()));
 assert_eq!(ISO_8859_6.decode(&[65,99,109,101,169], DecoderTrap::Ignore),
            Ok("Acme".to_string()));
-~~~~
+```
 
 To encode or decode the input into the already allocated buffer:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, EncoderTrap, DecoderTrap};
 use encoding::all::{ISO_8859_2, ISO_8859_6};
 
@@ -112,11 +112,11 @@ assert!(ISO_8859_6.decode_to(&[65,99,109,101,169], DecoderTrap::Replace, &mut ch
 
 assert_eq!(bytes, [65,99,109,101]);
 assert_eq!(chars, "Acme\u{fffd}");
-~~~~
+```
 
 A practical example of custom encoder traps:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, ByteWriter, EncoderTrap, DecoderTrap};
 use encoding::types::RawEncoder;
 use encoding::all::ASCII;
@@ -135,11 +135,11 @@ let orig = "Hello, 世界!".to_string();
 let encoded = ASCII.encode(&orig, HEX_NCR_ESCAPE).unwrap();
 assert_eq!(ASCII.decode(&encoded, DecoderTrap::Strict),
            Ok("Hello, &#x4e16;&#x754c;!".to_string()));
-~~~~
+```
 
 Getting the encoding from the string label, as specified in WHATWG Encoding standard:
 
-~~~~ {.rust}
+```rust
 use encoding::{Encoding, DecoderTrap};
 use encoding::label::encoding_from_whatwg_label;
 use encoding::all::WINDOWS_949;
@@ -154,7 +154,7 @@ assert_eq!(euckr.decode(broken, DecoderTrap::Replace),
 // corresponding Encoding native API:
 assert_eq!(WINDOWS_949.decode(broken, DecoderTrap::Replace),
            Ok("\u{c6b0}\u{c640}\u{fffd}\u{c559}".to_string()));
-~~~~
+```
 
 ## Types and Stuffs
 


### PR DESCRIPTION
Not sure about this. Maybe you need the other format for something.